### PR TITLE
Add comments to Java grammar.

### DIFF
--- a/grammars/java.l
+++ b/grammars/java.l
@@ -106,6 +106,4 @@ enum ENUM
 '(?:\\'|[^'\n])*' CHARACTER_LITERAL
 "(?:\\"|[^"\n])*" STRING_LITERAL
 [ \t\n\r]+ WHITESPACE
-//.*?$ ;
-/[*].*?[*]/ ;
-
+(//.*?$|/[*].*?[*]/) COMMENT

--- a/grammars/java.y
+++ b/grammars/java.y
@@ -1,5 +1,5 @@
 %start goal
-%implicit_tokens WHITESPACE
+%implicit_tokens WHITESPACE COMMENT
 %%
 goal : compilation_unit;
 

--- a/tests/Comment.java
+++ b/tests/Comment.java
@@ -1,0 +1,8 @@
+/* Multiline 1 */
+public /* Multiline 2 */ class /* Multiline 3 */ Comment /* Multiline 4 */ {
+    // Single line comment.
+} /* Multiline 5
+   *
+   *
+   *
+   */

--- a/tests/NestedComment.java
+++ b/tests/NestedComment.java
@@ -1,0 +1,4 @@
+/*
+ * // Single line comment nested in multi-line comment.
+ */
+public class NestedComment {}

--- a/tests/test_ast.rs
+++ b/tests/test_ast.rs
@@ -68,6 +68,7 @@ fn test_empty_calc() {
         "^~
  ~
   WHITESPACE  \n
+  ~
  Expr
   Term
    Factor
@@ -87,7 +88,8 @@ fn test_one_calc() {
    Factor
     INT 1
     ~
-     WHITESPACE \n\n",
+     WHITESPACE \n
+     ~\n",
     );
 }
 
@@ -110,8 +112,9 @@ fn test_add_calc() {
     Factor
      INT 2
      ~
-      WHITESPACE \n\n",
-    );
+      WHITESPACE \n
+      ~\n",
+      );
 }
 
 #[test]
@@ -139,7 +142,8 @@ fn test_mult_calc() {
     Factor
      INT 2
      ~
-      WHITESPACE \n\n",
+      WHITESPACE \n
+      ~\n",
     );
 }
 
@@ -163,17 +167,21 @@ fn test_hello_java() {
          modifier
           PUBLIC public
           ~
-           WHITESPACE  \n       CLASS class
+           WHITESPACE  \n           ~
+       CLASS class
        ~
-        WHITESPACE  \n       IDENTIFIER Hello
+        WHITESPACE  \n        ~
+       IDENTIFIER Hello
        ~
-        WHITESPACE  \n       type_parameters_opt
+        WHITESPACE  \n        ~
+       type_parameters_opt
        super_opt
        interfaces_opt
        class_body
         LBRACE {
         ~
-         WHITESPACE \n    \n        class_body_declarations_opt
+         WHITESPACE \n    \n         ~
+        class_body_declarations_opt
          class_body_declarations
           class_body_declaration
            class_member_declaration
@@ -185,12 +193,15 @@ fn test_hello_java() {
                  modifier
                   PUBLIC public
                   ~
-                   WHITESPACE  \n                modifier
+                   WHITESPACE  \n                   ~
+                modifier
                  STATIC static
                  ~
-                  WHITESPACE  \n              VOID void
+                  WHITESPACE  \n                  ~
+              VOID void
               ~
-               WHITESPACE  \n              method_declarator
+               WHITESPACE  \n               ~
+              method_declarator
                IDENTIFIER main
                ~
                LPAREN (
@@ -210,17 +221,20 @@ fn test_hello_java() {
                       ~
                       RBRACK ]
                       ~
-                       WHITESPACE  \n                  variable_declarator_id
+                       WHITESPACE  \n                       ~
+                  variable_declarator_id
                    IDENTIFIER args
                    ~
                RPAREN )
                ~
-                WHITESPACE  \n              throws_opt
+                WHITESPACE  \n                ~
+              throws_opt
              method_body
               block
                LBRACE {
                ~
-                WHITESPACE \n        \n               block_statements_opt
+                WHITESPACE \n        \n                ~
+               block_statements_opt
                 block_statements
                  block_statement
                   statement
@@ -273,14 +287,128 @@ fn test_hello_java() {
                        ~
                      SEMICOLON ;
                      ~
-                      WHITESPACE \n    \n               RBRACE }
+                      WHITESPACE \n    \n                      ~
+               RBRACE }
                ~
-                WHITESPACE \n
+                WHITESPACE \n\n                ~
+        RBRACE }
+        ~
+         WHITESPACE \n\n         ~
+",
+    );
+}
+
+#[test]
+fn test_comment_java() {
+    compare_ast_dump_to_lrpar_output(
+        true,
+        "tests/Comment.java",
+        "^~
+ ~
+  COMMENT /* Multiline 1 */
+  ~
+   WHITESPACE \n
+   ~
+ goal
+  compilation_unit
+   package_declaration_opt
+   import_declarations_opt
+   type_declarations_opt
+    type_declarations
+     type_declaration
+      class_declaration
+       modifiers_opt
+        modifiers
+         modifier
+          PUBLIC public
+          ~
+           WHITESPACE  \n           ~
+            COMMENT /* Multiline 2 */
+            ~
+             WHITESPACE  \n             ~
+       CLASS class
+       ~
+        WHITESPACE  \n        ~
+         COMMENT /* Multiline 3 */
+         ~
+          WHITESPACE  \n          ~
+       IDENTIFIER Comment
+       ~
+        WHITESPACE  \n        ~
+         COMMENT /* Multiline 4 */
+         ~
+          WHITESPACE  \n          ~
+       type_parameters_opt
+       super_opt
+       interfaces_opt
+       class_body
+        LBRACE {
+        ~
+         WHITESPACE \n    \n         ~
+          COMMENT // Single line comment.
+          ~
+           WHITESPACE \n
+           ~
+        class_body_declarations_opt
+        RBRACE }
+        ~
+         WHITESPACE  \n         ~
+          COMMENT /* Multiline 5
+   *
+   *
+   *
+   */
+          ~
+           WHITESPACE \n
+           ~
+");
+}
+
+#[test]
+fn test_nested_comment_java() {
+    compare_ast_dump_to_lrpar_output(
+        true,
+        "tests/NestedComment.java",
+        "^~
+ ~
+  COMMENT /*
+ * // Single line comment nested in multi-line comment.
+ */
+  ~
+   WHITESPACE \n
+   ~
+ goal
+  compilation_unit
+   package_declaration_opt
+   import_declarations_opt
+   type_declarations_opt
+    type_declarations
+     type_declaration
+      class_declaration
+       modifiers_opt
+        modifiers
+         modifier
+          PUBLIC public
+          ~
+           WHITESPACE  \n           ~
+       CLASS class
+       ~
+        WHITESPACE  \n        ~
+       IDENTIFIER NestedComment
+       ~
+        WHITESPACE  \n        ~
+       type_parameters_opt
+       super_opt
+       interfaces_opt
+       class_body
+        LBRACE {
+        ~
+        class_body_declarations_opt
         RBRACE }
         ~
          WHITESPACE \n
-",
-    );
+         ~
+");
 }
 
 #[test]


### PR DESCRIPTION
Example test case:

```java
/* Multiline 1 */
public /* Multiline 2 */ class /* Multiline 3 */ Comment /* Multiline 4 */ {
    // Single line comment.
} /* Multiline 5
   *
   *
   *
   */
```

Parser output:

![comment](https://user-images.githubusercontent.com/97674/30166287-c73cbdf0-93da-11e7-8b1a-ccac8b9e4df5.png)
