### PR TITLE
Test whether nodes were mapped by matcher (rather than the edit script generator).

### DIFF
--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -149,13 +149,13 @@ impl Chawathe96Config {
             from_in_order.insert(a);
             to_in_order.insert(b);
         }
-        // 6. For each a in s1, b in s2 such that (a, b) in new_mappings but
+        // 6. For each a in s1, b in s2 such that (a, b) in store (M) but
         // (a, b) not in lcs: (i) let k = find_pos(b); (ii) append MOV(a, w, k)
         // to the script and apply MOV(a, w, k) to T_1; (iii) Mark a, b as "in
         // order".
         for a in &s1 {
             for b in &s2 {
-                if store.is_mapped(a, b) && !lcs.contains(&(*a, *b)) {
+                if store.is_mapped_by_matcher(a, b) && !lcs.contains(&(*a, *b)) {
                     let k = self.find_pos(store, *b, from_in_order, to_in_order);
                     let mut mov = Move::new(*a, w, k);
                     debug!(

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -155,12 +155,24 @@ impl<T: Clone + Debug + Eq + 'static> MappingStore<T> {
         self.from.get(from).and_then(|x| Some(x.0))
     }
 
-    /// Test whether `n1` is mapped to `n2` in this store.
+    /// Test whether `from` is mapped to `to` in this store.
     pub fn is_mapped(&self, from: &NodeId, to: &NodeId) -> bool {
         if !self.contains_from(from) {
             return false;
         }
         self.get_to(from).map_or(false, |x| x == *to)
+    }
+
+    /// Test whether `from` is mapped to `to` by the matcher.
+    /// As opposed to the edit script generator.
+    pub fn is_mapped_by_matcher(&self, from: &NodeId, to: &NodeId) -> bool {
+        if !self.contains_from(from) {
+            return false;
+        }
+        match self.from.get(from) {
+            None => false,
+            Some(&(val, ref ty)) => val == *to && *ty != MappingType::EDIT
+        }
     }
 
     /// Two sub-trees are isomorphic if they have the same structure.
@@ -416,6 +428,52 @@ mod tests {
         assert!(store.is_mapping_allowed(&NodeId::new(1), &NodeId::new(3)));
         assert!(!store.is_mapping_allowed(&NodeId::new(2), &NodeId::new(4)));
         assert!(!store.is_mapping_allowed(&NodeId::new(0), &NodeId::new(0)));
+    }
+
+    #[test]
+    fn is_mapped() {
+        let mult = create_mult_arena();
+        let plus = create_plus_arena();
+        let mut store = MappingStore::new(plus, mult);
+        store.push(NodeId::new(0), NodeId::new(0), &MappingType::ANCHOR);
+        store.push(NodeId::new(2), NodeId::new(4), &MappingType::ANCHOR);
+        assert!(store.is_mapped(&NodeId::new(0), &NodeId::new(0)));
+        assert!(store.is_mapped(&NodeId::new(2), &NodeId::new(4)));
+        // Not mapped.
+        assert!(!store.is_mapped(&NodeId::new(0), &NodeId::new(1)));
+        assert!(!store.is_mapped(&NodeId::new(0), &NodeId::new(2)));
+        assert!(!store.is_mapped(&NodeId::new(0), &NodeId::new(3)));
+        assert!(!store.is_mapped(&NodeId::new(0), &NodeId::new(4)));
+        assert!(!store.is_mapped(&NodeId::new(1), &NodeId::new(1)));
+        assert!(!store.is_mapped(&NodeId::new(1), &NodeId::new(2)));
+        assert!(!store.is_mapped(&NodeId::new(1), &NodeId::new(3)));
+        assert!(!store.is_mapped(&NodeId::new(1), &NodeId::new(4)));
+        assert!(!store.is_mapped(&NodeId::new(2), &NodeId::new(1)));
+        assert!(!store.is_mapped(&NodeId::new(2), &NodeId::new(2)));
+        assert!(!store.is_mapped(&NodeId::new(2), &NodeId::new(3)));
+    }
+
+    #[test]
+    fn is_mapped_by_matcher() {
+        let mult = create_mult_arena();
+        let plus = create_plus_arena();
+        let mut store = MappingStore::new(plus, mult);
+        store.push(NodeId::new(0), NodeId::new(0), &MappingType::CONTAINER);
+        store.push(NodeId::new(2), NodeId::new(4), &MappingType::EDIT);
+        assert!(store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(0)));
+        // Not mapped.
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(1)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(2)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(3)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(4)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(1), &NodeId::new(1)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(1), &NodeId::new(2)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(1), &NodeId::new(3)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(1), &NodeId::new(4)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(2), &NodeId::new(1)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(2), &NodeId::new(2)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(2), &NodeId::new(3)));
+        assert!(!store.is_mapped_by_matcher(&NodeId::new(2), &NodeId::new(4)));
     }
 
     #[test]


### PR DESCRIPTION
This fixes a bug that was introduced in #52 