### PR TITLE
Remove indent from AST nodes.

### DIFF
--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -372,14 +372,12 @@ mod test {
         let mut arena = Arena::new();
         let root = arena.new_node(String::from("+"),
                                   String::from("Expr"),
-                                  0,
                                   None,
                                   None,
                                   None,
                                   None);
         let n1 = arena.new_node(String::from("1"),
                                 String::from("INT"),
-                                2,
                                 None,
                                 None,
                                 None,
@@ -387,7 +385,6 @@ mod test {
         n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node(String::from("*"),
                                 String::from("Expr"),
-                                2,
                                 None,
                                 None,
                                 None,
@@ -395,7 +392,6 @@ mod test {
         n2.make_child_of(root, &mut arena).unwrap();
         let n3 = arena.new_node(String::from("3"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
@@ -403,7 +399,6 @@ mod test {
         n3.make_child_of(n2, &mut arena).unwrap();
         let n4 = arena.new_node(String::from("4"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
@@ -415,35 +410,35 @@ mod test {
     #[test]
     fn apply_delete_leaf() {
         let mut arena = create_arena();
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         let mut del1 = Delete::new(NodeId::new(3));
         del1.apply(&mut arena).unwrap();
         let mut del2 = Delete::new(NodeId::new(4));
         del2.apply(&mut arena).unwrap();
-        let format2 = "Expr +
-  INT 1
-  Expr *
+        let format2 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
 ";
-        assert_eq!(format2, format!("{}", arena));
+        assert_eq!(format2, format!("{:?}", arena));
     }
 
     #[test]
     #[should_panic]
     fn apply_delete_branch() {
         let mut arena = create_arena();
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         let mut del = Delete::new(NodeId::new(2));
         del.apply(&mut arena).unwrap();
     }
@@ -453,28 +448,27 @@ mod test {
         let mut arena = create_arena();
         let n5 = arena.new_node(String::from("100"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
                                 None);
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         let mut ins = Insert::new(n5, Some(NodeId::new(2)), 0);
         ins.apply(&mut arena).unwrap();
-        let format2 = "Expr +
-  INT 1
-  Expr *
-    INT 100
-    INT 3
-    INT 4
+        let format2 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"100\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format2, format!("{}", arena));
+        assert_eq!(format2, format!("{:?}", arena));
     }
 
     #[test]
@@ -482,97 +476,94 @@ mod test {
         let mut arena = create_arena();
         let n5 = arena.new_node(String::from("-"),
                                 String::from("Expr"),
-                                0,
                                 None,
                                 None,
                                 None,
                                 None);
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         let mut ins = Insert::new(n5, None, 0);
         ins.apply(&mut arena).unwrap();
-        let format2 = "Expr -
-Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format2 = "Expr \"-\"
+  Expr \"+\"
+    INT \"1\"
+    Expr \"*\"
+      INT \"3\"
+      INT \"4\"
 ";
-        assert_eq!(format2, format!("{}", arena));
+        assert_eq!(format2, format!("{:?}", arena));
     }
 
     #[test]
     fn apply_move() {
         let mut arena = create_arena();
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         let mut mov = Move::new(NodeId::new(4), NodeId::new(2), 0);
         mov.apply(&mut arena).unwrap();
-        let format2 = "Expr +
-  INT 1
-  Expr *
-    INT 4
-    INT 3
+        let format2 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"4\"
+    INT \"3\"
 ";
-        assert_eq!(format2, format!("{}", arena));
+        assert_eq!(format2, format!("{:?}", arena));
     }
 
     #[test]
     fn apply_update() {
         let mut arena = create_arena();
         assert_eq!(5, arena.size());
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         let mut upd = Update::new(NodeId::new(2), String::from("+"), String::from("Expr"));
         upd.apply(&mut arena).unwrap();
-        let format2 = "Expr +
-  INT 1
-  Expr +
-    INT 3
-    INT 4
+        let format2 = "Expr \"+\"
+  INT \"1\"
+  Expr \"+\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format2, format!("{}", arena));
+        assert_eq!(format2, format!("{:?}", arena));
     }
 
     #[test]
     fn apply_to_list1() {
         let mut arena = create_arena();
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
         let n5 = arena.new_node(String::from("100"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
                                 None);
         let n6 = arena.new_node(String::from("99"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
                                 None);
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         // Create action list.
         let mut actions: EditScript<String> = EditScript::new();
         let del1 = Delete::new(NodeId::new(3)); // INT 3
@@ -590,28 +581,27 @@ Expr +
         actions.push(upd);
         // Apply action list.
         actions.apply(&mut arena).unwrap();
-        let format2 = "Expr *
-  INT 1
-  Expr *
-    INT 99
-    INT 100
+        let format2 = "Expr \"*\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"99\"
+    INT \"100\"
 ";
-        assert_eq!(format2, format!("{}", arena));
+        assert_eq!(format2, format!("{:?}", arena));
     }
 
     #[test]
     fn apply_to_list2() {
         let mut arena = create_arena();
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         let n5 = arena.new_node(String::from("2"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
@@ -635,13 +625,13 @@ Expr +
         actions.push(upd);
         // Apply action list.
         actions.apply(&mut arena).unwrap();
-        let format2 = "Expr *
-  INT 1
-  Expr *
-    INT 2
-    INT 3
+        let format2 = "Expr \"*\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"2\"
+    INT \"3\"
 ";
-        assert_eq!(format2, format!("{}", arena));
+        assert_eq!(format2, format!("{:?}", arena));
     }
 
     #[test]

--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -300,7 +300,6 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                 w = store.from_arena.new_node(
                     store.to_arena[x].value.clone(),
                     store.to_arena[x].label.clone(),
-                    store.to_arena[x].indent,
                     store.to_arena[x].col_no,
                     store.to_arena[x].line_no,
                     store.to_arena[x].char_no,
@@ -325,7 +324,6 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                 w = store.from_arena.new_node(
                     store.to_arena[x].value.clone(),
                     store.to_arena[x].label.clone(),
-                    store.to_arena[x].indent,
                     store.to_arena[x].col_no,
                     store.to_arena[x].line_no,
                     store.to_arena[x].char_no,

--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -186,14 +186,12 @@ mod tests {
         let mut arena = Arena::new();
         let root = arena.new_node(String::from("+"),
                                   String::from("Expr"),
-                                  0,
                                   None,
                                   None,
                                   None,
                                   None);
         let n1 = arena.new_node(String::from("1"),
                                 String::from("INT"),
-                                2,
                                 None,
                                 None,
                                 None,
@@ -201,7 +199,6 @@ mod tests {
         n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node(String::from("*"),
                                 String::from("Expr"),
-                                2,
                                 None,
                                 None,
                                 None,
@@ -209,7 +206,6 @@ mod tests {
         n2.make_child_of(root, &mut arena).unwrap();
         let n3 = arena.new_node(String::from("3"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
@@ -217,19 +213,18 @@ mod tests {
         n3.make_child_of(n2, &mut arena).unwrap();
         let n4 = arena.new_node(String::from("4"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
                                 None);
         n4.make_child_of(n2, &mut arena).unwrap();
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         arena
     }
 
@@ -364,7 +359,6 @@ mod tests {
         for _ in 0..BENCH_ITER {
             arena.new_node(String::from(""),
                            String::from(""),
-                           0,
                            None,
                            None,
                            None,

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -303,14 +303,12 @@ mod tests {
         let mut arena = Arena::new();
         let root = arena.new_node(String::from("+"),
                                   String::from("Expr"),
-                                  0,
                                   None,
                                   None,
                                   None,
                                   None);
         let n1 = arena.new_node(String::from("1"),
                                 String::from("INT"),
-                                2,
                                 None,
                                 None,
                                 None,
@@ -318,7 +316,6 @@ mod tests {
         n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node(String::from("*"),
                                 String::from("Expr"),
-                                2,
                                 None,
                                 None,
                                 None,
@@ -326,7 +323,6 @@ mod tests {
         n2.make_child_of(root, &mut arena).unwrap();
         let n3 = arena.new_node(String::from("3"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
@@ -334,19 +330,18 @@ mod tests {
         n3.make_child_of(n2, &mut arena).unwrap();
         let n4 = arena.new_node(String::from("4"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
                                 None);
         n4.make_child_of(n2, &mut arena).unwrap();
-        let format1 = "Expr +
-  INT 1
-  Expr *
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         arena
     }
 
@@ -354,14 +349,12 @@ mod tests {
         let mut arena = Arena::new();
         let root = arena.new_node(String::from("+"),
                                   String::from("Expr"),
-                                  0,
                                   None,
                                   None,
                                   None,
                                   None);
         let n1 = arena.new_node(String::from("3"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
@@ -369,17 +362,16 @@ mod tests {
         n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node(String::from("4"),
                                 String::from("INT"),
-                                4,
                                 None,
                                 None,
                                 None,
                                 None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let format1 = "Expr +
-    INT 3
-    INT 4
+        let format1 = "Expr \"+\"
+  INT \"3\"
+  INT \"4\"
 ";
-        assert_eq!(format1, format!("{}", arena));
+        assert_eq!(format1, format!("{:?}", arena));
         arena
     }
 

--- a/src/lib/sequence.rs
+++ b/src/lib/sequence.rs
@@ -179,14 +179,13 @@ mod tests {
         if !base.is_empty() {
             let root = base_arena.new_node(Default::default(),
                                            String::from("NULL"),
-                                           0,
                                            None,
                                            None,
                                            None,
                                            None);
             for value in base {
                 id = base_arena
-                    .new_node(value.clone(), String::from("T"), 0, None, None, None, None);
+                    .new_node(value.clone(), String::from("T"), None, None, None, None);
                 id.make_child_of(root, &mut base_arena).unwrap();
 
             }
@@ -195,14 +194,13 @@ mod tests {
         if !diff.is_empty() {
             let root = diff_arena.new_node(Default::default(),
                                            String::from("NULL"),
-                                           0,
                                            None,
                                            None,
                                            None,
                                            None);
             for value in diff {
                 id = diff_arena
-                    .new_node(value.clone(), String::from("T"), 0, None, None, None, None);
+                    .new_node(value.clone(), String::from("T"), None, None, None, None);
                 id.make_child_of(root, &mut diff_arena).unwrap();
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,8 +369,8 @@ fn main() {
 
     // Dump ASTs to STDOUT, if requested.
     if args.flag_ast {
-        println!("{}", ast_base);
-        println!("{}", ast_diff);
+        println!("{:?}", ast_base);
+        println!("{:?}", ast_diff);
     }
 
     // Generate graphviz file(s), if requested.

--- a/tests/test_ast.rs
+++ b/tests/test_ast.rs
@@ -56,7 +56,7 @@ fn compare_ast_dump_to_lrpar_output(is_java: bool, filepath: &str, expected: &st
         Path::new("grammars/calc.y")
     };
     let arena = parse_file(filepath, lex, yacc).unwrap();
-    let arena_pretty_printed = format!("{:}", arena);
+    let arena_pretty_printed = format!("{:?}", arena);
     // Remove `\r` from pretty printed string, as the 'expected' values all
     // use UNIX line endings.
     let pp_unix = arena_pretty_printed.replace("\r", "");
@@ -69,12 +69,12 @@ fn test_empty_calc() {
         false,
         "tests/empty.calc",
         "^~
- ~
-  WHITESPACE  \n
   ~
- Expr
-  Term
-   Factor
+    WHITESPACE \" \\n\"
+    ~
+  Expr
+    Term
+      Factor
 ",
     );
 }
@@ -85,14 +85,15 @@ fn test_one_calc() {
         false,
         "tests/one.calc",
         "^~
- ~
- Expr
-  Term
-   Factor
-    INT 1
-    ~
-     WHITESPACE \n
-     ~\n",
+  ~
+  Expr
+    Term
+      Factor
+        INT \"1\"
+        ~
+          WHITESPACE \"\\n\"
+          ~
+",
     );
 }
 
@@ -102,22 +103,23 @@ fn test_add_calc() {
         false,
         "tests/add.calc",
         "^~
- ~
- Expr
-  Term
-   Factor
-    INT 1
-    ~
-  PLUS +
   ~
   Expr
-   Term
-    Factor
-     INT 2
-     ~
-      WHITESPACE \n
-      ~\n",
-      );
+    Term
+      Factor
+        INT \"1\"
+        ~
+    PLUS \"+\"
+    ~
+    Expr
+      Term
+        Factor
+          INT \"2\"
+          ~
+            WHITESPACE \"\\n\"
+            ~
+",
+    );
 }
 
 #[test]
@@ -126,27 +128,28 @@ fn test_mult_calc() {
         false,
         "tests/mult.calc",
         "^~
- ~
- Expr
-  Term
-   Factor
-    INT 3
-    ~
-   MULT *
-   ~
-   Term
-    Factor
-     INT 1
-     ~
-  PLUS +
   ~
   Expr
-   Term
-    Factor
-     INT 2
-     ~
-      WHITESPACE \n
-      ~\n",
+    Term
+      Factor
+        INT \"3\"
+        ~
+      MULT \"*\"
+      ~
+      Term
+        Factor
+          INT \"1\"
+          ~
+    PLUS \"+\"
+    ~
+    Expr
+      Term
+        Factor
+          INT \"2\"
+          ~
+            WHITESPACE \"\\n\"
+            ~
+",
     );
 }
 
@@ -155,148 +158,161 @@ fn test_hello_java() {
     compare_ast_dump_to_lrpar_output(
         true,
         "tests/Hello.java",
-       "^~
- ~
- goal
-  compilation_unit
-   package_declaration_opt
-   import_declarations_opt
-   type_declarations_opt
-    type_declarations
-     type_declaration
-      class_declaration
-       modifiers_opt
-        modifiers
-         modifier
-          PUBLIC public
-          ~
-           WHITESPACE  \n           ~
-       CLASS class
-       ~
-        WHITESPACE  \n        ~
-       IDENTIFIER Hello
-       ~
-        WHITESPACE  \n        ~
-       type_parameters_opt
-       super_opt
-       interfaces_opt
-       class_body
-        LBRACE {
-        ~
-         WHITESPACE \n    \n         ~
-        class_body_declarations_opt
-         class_body_declarations
-          class_body_declaration
-           class_member_declaration
-            method_declaration
-             method_header
+        "^~
+  ~
+  goal
+    compilation_unit
+      package_declaration_opt
+      import_declarations_opt
+      type_declarations_opt
+        type_declarations
+          type_declaration
+            class_declaration
               modifiers_opt
-               modifiers
                 modifiers
-                 modifier
-                  PUBLIC public
-                  ~
-                   WHITESPACE  \n                   ~
-                modifier
-                 STATIC static
-                 ~
-                  WHITESPACE  \n                  ~
-              VOID void
+                  modifier
+                    PUBLIC \"public\"
+                    ~
+                      WHITESPACE \" \"
+                      ~
+              CLASS \"class\"
               ~
-               WHITESPACE  \n               ~
-              method_declarator
-               IDENTIFIER main
-               ~
-               LPAREN (
-               ~
-               formal_parameter_list_opt
-                formal_parameter_list
-                 formal_parameter
-                  type
-                   reference_type
-                    array_type
-                     name
-                      simple_name
-                       IDENTIFIER String
-                       ~
-                     dims
-                      LBRACK [
-                      ~
-                      RBRACK ]
-                      ~
-                       WHITESPACE  \n                       ~
-                  variable_declarator_id
-                   IDENTIFIER args
-                   ~
-               RPAREN )
-               ~
-                WHITESPACE  \n                ~
-              throws_opt
-             method_body
-              block
-               LBRACE {
-               ~
-                WHITESPACE \n        \n                ~
-               block_statements_opt
-                block_statements
-                 block_statement
-                  statement
-                   statement_without_trailing_substatement
-                    expression_statement
-                     statement_expression
-                      method_invocation
-                       qualified_name
-                        name
-                         qualified_name
-                          name
-                           simple_name
-                            IDENTIFIER System
+                WHITESPACE \" \"
+                ~
+              IDENTIFIER \"Hello\"
+              ~
+                WHITESPACE \" \"
+                ~
+              type_parameters_opt
+              super_opt
+              interfaces_opt
+              class_body
+                LBRACE \"{\"
+                ~
+                  WHITESPACE \"\\n    \"
+                  ~
+                class_body_declarations_opt
+                  class_body_declarations
+                    class_body_declaration
+                      class_member_declaration
+                        method_declaration
+                          method_header
+                            modifiers_opt
+                              modifiers
+                                modifiers
+                                  modifier
+                                    PUBLIC \"public\"
+                                    ~
+                                      WHITESPACE \" \"
+                                      ~
+                                modifier
+                                  STATIC \"static\"
+                                  ~
+                                    WHITESPACE \" \"
+                                    ~
+                            VOID \"void\"
                             ~
-                          DOT .
-                          ~
-                          IDENTIFIER out
-                          ~
-                        DOT .
-                        ~
-                        IDENTIFIER println
-                        ~
-                       LPAREN (
-                       ~
-                       argument_list_opt
-                        argument_list
-                         expression
-                          assignment_expression
-                           conditional_expression
-                            conditional_or_expression
-                             conditional_and_expression
-                              inclusive_or_expression
-                               exclusive_or_expression
-                                and_expression
-                                 equality_expression
-                                  instanceof_expression
-                                   relational_expression
-                                    shift_expression
-                                     additive_expression
-                                      multiplicative_expression
-                                       unary_expression
-                                        unary_expression_not_plus_minus
-                                         postfix_expression
-                                          primary
-                                           primary_no_new_array
-                                            literal
-                                             STRING_LITERAL \"Hello, world!\"
-                                             ~
-                       RPAREN )
-                       ~
-                     SEMICOLON ;
-                     ~
-                      WHITESPACE \n    \n                      ~
-               RBRACE }
-               ~
-                WHITESPACE \n\n                ~
-        RBRACE }
-        ~
-         WHITESPACE \n\n         ~
+                              WHITESPACE \" \"
+                              ~
+                            method_declarator
+                              IDENTIFIER \"main\"
+                              ~
+                              LPAREN \"(\"
+                              ~
+                              formal_parameter_list_opt
+                                formal_parameter_list
+                                  formal_parameter
+                                    type
+                                      reference_type
+                                        array_type
+                                          name
+                                            simple_name
+                                              IDENTIFIER \"String\"
+                                              ~
+                                          dims
+                                            LBRACK \"[\"
+                                            ~
+                                            RBRACK \"]\"
+                                            ~
+                                              WHITESPACE \" \"
+                                              ~
+                                    variable_declarator_id
+                                      IDENTIFIER \"args\"
+                                      ~
+                              RPAREN \")\"
+                              ~
+                                WHITESPACE \" \"
+                                ~
+                            throws_opt
+                          method_body
+                            block
+                              LBRACE \"{\"
+                              ~
+                                WHITESPACE \"\\n        \"
+                                ~
+                              block_statements_opt
+                                block_statements
+                                  block_statement
+                                    statement
+                                      statement_without_trailing_substatement
+                                        expression_statement
+                                          statement_expression
+                                            method_invocation
+                                              qualified_name
+                                                name
+                                                  qualified_name
+                                                    name
+                                                      simple_name
+                                                        IDENTIFIER \"System\"
+                                                        ~
+                                                    DOT \".\"
+                                                    ~
+                                                    IDENTIFIER \"out\"
+                                                    ~
+                                                DOT \".\"
+                                                ~
+                                                IDENTIFIER \"println\"
+                                                ~
+                                              LPAREN \"(\"
+                                              ~
+                                              argument_list_opt
+                                                argument_list
+                                                  expression
+                                                    assignment_expression
+                                                      conditional_expression
+                                                        conditional_or_expression
+                                                          conditional_and_expression
+                                                            inclusive_or_expression
+                                                              exclusive_or_expression
+                                                                and_expression
+                                                                  equality_expression
+                                                                    instanceof_expression
+                                                                      relational_expression
+                                                                        shift_expression
+                                                                          additive_expression
+                                                                            multiplicative_expression
+                                                                              unary_expression
+                                                                                unary_expression_not_plus_minus
+                                                                                  postfix_expression
+                                                                                    primary
+                                                                                      primary_no_new_array
+                                                                                        literal
+                                                                                          STRING_LITERAL \"\\\"Hello, world!\\\"\"
+                                                                                          ~
+                                              RPAREN \")\"
+                                              ~
+                                          SEMICOLON \";\"
+                                          ~
+                                            WHITESPACE \"\\n    \"
+                                            ~
+                              RBRACE \"}\"
+                              ~
+                                WHITESPACE \"\\n\"
+                                ~
+                RBRACE \"}\"
+                ~
+                  WHITESPACE \"\\n\"
+                  ~
 ",
     );
 }
@@ -307,64 +323,69 @@ fn test_comment_java() {
         true,
         "tests/Comment.java",
         "^~
- ~
-  COMMENT /* Multiline 1 */
   ~
-   WHITESPACE \n
-   ~
- goal
-  compilation_unit
-   package_declaration_opt
-   import_declarations_opt
-   type_declarations_opt
-    type_declarations
-     type_declaration
-      class_declaration
-       modifiers_opt
-        modifiers
-         modifier
-          PUBLIC public
-          ~
-           WHITESPACE  \n           ~
-            COMMENT /* Multiline 2 */
-            ~
-             WHITESPACE  \n             ~
-       CLASS class
-       ~
-        WHITESPACE  \n        ~
-         COMMENT /* Multiline 3 */
-         ~
-          WHITESPACE  \n          ~
-       IDENTIFIER Comment
-       ~
-        WHITESPACE  \n        ~
-         COMMENT /* Multiline 4 */
-         ~
-          WHITESPACE  \n          ~
-       type_parameters_opt
-       super_opt
-       interfaces_opt
-       class_body
-        LBRACE {
-        ~
-         WHITESPACE \n    \n         ~
-          COMMENT // Single line comment.
-          ~
-           WHITESPACE \n
-           ~
-        class_body_declarations_opt
-        RBRACE }
-        ~
-         WHITESPACE  \n         ~
-          COMMENT /* Multiline 5
-   *
-   *
-   *
-   */
-          ~
-           WHITESPACE \n
-           ~
-");
+    COMMENT \"/* Multiline 1 */\"
+    ~
+      WHITESPACE \"\\n\"
+      ~
+  goal
+    compilation_unit
+      package_declaration_opt
+      import_declarations_opt
+      type_declarations_opt
+        type_declarations
+          type_declaration
+            class_declaration
+              modifiers_opt
+                modifiers
+                  modifier
+                    PUBLIC \"public\"
+                    ~
+                      WHITESPACE \" \"
+                      ~
+                        COMMENT \"/* Multiline 2 */\"
+                        ~
+                          WHITESPACE \" \"
+                          ~
+              CLASS \"class\"
+              ~
+                WHITESPACE \" \"
+                ~
+                  COMMENT \"/* Multiline 3 */\"
+                  ~
+                    WHITESPACE \" \"
+                    ~
+              IDENTIFIER \"Comment\"
+              ~
+                WHITESPACE \" \"
+                ~
+                  COMMENT \"/* Multiline 4 */\"
+                  ~
+                    WHITESPACE \" \"
+                    ~
+              type_parameters_opt
+              super_opt
+              interfaces_opt
+              class_body
+                LBRACE \"{\"
+                ~
+                  WHITESPACE \"\\n    \"
+                  ~
+                    COMMENT \"// Single line comment.\"
+                    ~
+                      WHITESPACE \"\\n\"
+                      ~
+                class_body_declarations_opt
+                RBRACE \"}\"
+                ~
+                  WHITESPACE \" \"
+                  ~
+                    COMMENT \"/* Multiline 5\\n   *\\n   *\\n   *\\n   */\"
+                    ~
+                      WHITESPACE \"\\n\"
+                      ~
+",
+    );
 }
 
 #[test]
@@ -373,45 +394,47 @@ fn test_nested_comment_java() {
         true,
         "tests/NestedComment.java",
         "^~
- ~
-  COMMENT /*
- * // Single line comment nested in multi-line comment.
- */
   ~
-   WHITESPACE \n
-   ~
- goal
-  compilation_unit
-   package_declaration_opt
-   import_declarations_opt
-   type_declarations_opt
-    type_declarations
-     type_declaration
-      class_declaration
-       modifiers_opt
-        modifiers
-         modifier
-          PUBLIC public
-          ~
-           WHITESPACE  \n           ~
-       CLASS class
-       ~
-        WHITESPACE  \n        ~
-       IDENTIFIER NestedComment
-       ~
-        WHITESPACE  \n        ~
-       type_parameters_opt
-       super_opt
-       interfaces_opt
-       class_body
-        LBRACE {
-        ~
-        class_body_declarations_opt
-        RBRACE }
-        ~
-         WHITESPACE \n
-         ~
-");
+    COMMENT \"/*\\n * // Single line comment nested in multi-line comment.\\n */\"
+    ~
+      WHITESPACE \"\\n\"
+      ~
+  goal
+    compilation_unit
+      package_declaration_opt
+      import_declarations_opt
+      type_declarations_opt
+        type_declarations
+          type_declaration
+            class_declaration
+              modifiers_opt
+                modifiers
+                  modifier
+                    PUBLIC \"public\"
+                    ~
+                      WHITESPACE \" \"
+                      ~
+              CLASS \"class\"
+              ~
+                WHITESPACE \" \"
+                ~
+              IDENTIFIER \"NestedComment\"
+              ~
+                WHITESPACE \" \"
+                ~
+              type_parameters_opt
+              super_opt
+              interfaces_opt
+              class_body
+                LBRACE \"{\"
+                ~
+                class_body_declarations_opt
+                RBRACE \"}\"
+                ~
+                  WHITESPACE \"\\n\"
+                  ~
+",
+    );
 }
 
 #[test]


### PR DESCRIPTION
Indentation has been stored inside AST nodes since the AST module was first written.
However, now we have whitespace-aware grammars, there is no need to store indentation separately.
The `Debug` trait (on `Node` and `Arena` types) now adds indentation to its output (similarly to `lrpar`).
Tests have been updated to match the new API.

In this PR, the `ast.rs` file has changed some functionality (the other files have just changed to match the new APIs). The diffs are unfortunately very large because a large number of test cases that needed changing, but the changes in functionality are relatively small.

This fixes a more fundamental problem about moving nodes. If we have this tree:

```
Expr +
    INT 1
    INT 2
```

and move the nodes around to make `INT 1` the new root, keeping indentation within the nodes creates a misleading representation of the resulting tree:

```
INT 1
    Expr +
INT 2
```

which clearly should be:

```
INT 1
    Expr +
    INT 2
```