### PR TITLE
Fix issue 57

### DIFF
--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -41,6 +41,7 @@ use std::collections::VecDeque;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::fs::File;
+use std::marker::PhantomData;
 use std::io::Read;
 use std::ops::{Index, IndexMut};
 use std::path::Path;
@@ -53,8 +54,8 @@ use lrtable::{Minimiser, from_yacc};
 
 use hqueue::HeightQueue;
 
-#[derive(Debug)]
 /// Errors raised when parsing a source file.
+#[derive(Debug)]
 pub enum ParseError {
     /// Io error returned from standard library routines.
     Io(String),
@@ -70,8 +71,8 @@ pub enum ParseError {
     SyntaxError,
 }
 
-#[derive(Debug)]
 /// Errors raised by arenas.
+#[derive(Debug)]
 pub enum ArenaError {
     /// Arena is unexpectedly empty.
     EmtpyArena,
@@ -86,37 +87,46 @@ pub enum ArenaError {
 /// Result type returned by AST operations.
 pub type ArenaResult = Result<(), ArenaError>;
 
+/// A node identifier for a 'from' `Arena`.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
+pub struct FromNodeId;
+
+/// A node identifier for a 'to' `Arena`.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
+pub struct ToNodeId;
+
 /// A node identifier used for indexing nodes within a particular `Arena`.
 ///
 /// A `NodeId` should be immutable, in the sense that no action on a node or
 /// arena should change a given `NodeId`.
-pub struct NodeId {
+#[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd)]
+pub struct NodeId<T: PartialEq + Copy> {
     index: usize,
+    phantom: PhantomData<T>,
 }
 
-impl fmt::Display for NodeId {
+impl<T: PartialEq + Copy> fmt::Display for NodeId<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.index)
     }
 }
 
 /// A type to represent edges between nodes within an `Arena`.
-pub type EdgeId = (NodeId, NodeId);
+pub type EdgeId<T> = (NodeId<T>, NodeId<T>);
 
-#[derive(Clone)]
 /// An arena in which to place `NodeId`-indexed AST nodes.
 ///
 /// `T` type is given to internal values stored within each node.
 /// These values contain information that the `lrpar` crate will provide, and
 /// represent any lexical information (e.g. literals) from the original text.
-pub struct Arena<T: Clone> {
-    nodes: Vec<Node<T>>,
-    root: Option<NodeId>,
+#[derive(Clone)]
+pub struct Arena<T: Clone, U: PartialEq + Copy> {
+    nodes: Vec<Node<T, U>>,
+    root: Option<NodeId<U>>,
 }
 
-impl<T: Clone> Default for Arena<T> {
-    fn default() -> Arena<T> {
+impl<T: Clone, U: PartialEq + Copy> Default for Arena<T, U> {
+    fn default() -> Arena<T, U> {
         Arena {
             nodes: Vec::new(),
             root: None,
@@ -124,23 +134,53 @@ impl<T: Clone> Default for Arena<T> {
     }
 }
 
-impl<T: Clone> Index<NodeId> for Arena<T> {
-    type Output = Node<T>;
+impl<T: Clone, U: PartialEq + Copy> Index<NodeId<U>> for Arena<T, U> {
+    type Output = Node<T, U>;
 
-    fn index(&self, node: NodeId) -> &Node<T> {
+    fn index(&self, node: NodeId<U>) -> &Node<T, U> {
         &self.nodes[node.index]
     }
 }
 
-impl<T: Clone> IndexMut<NodeId> for Arena<T> {
-    fn index_mut(&mut self, node: NodeId) -> &mut Node<T> {
+impl<T: Clone, U: PartialEq + Copy> IndexMut<NodeId<U>> for Arena<T, U> {
+    fn index_mut(&mut self, node: NodeId<U>) -> &mut Node<T, U> {
         &mut self.nodes[node.index]
     }
 }
 
-impl<T: Clone> Arena<T> {
+#[cfg(test)]
+impl<T: Clone> From<Arena<T, ToNodeId>> for Arena<T, FromNodeId> {
+    fn from(arena: Arena<T, ToNodeId>) -> Self {
+        let coerced = arena.nodes
+                           .iter()
+                           .cloned()
+                           .map(|node| Node::<T, FromNodeId>::from(node))
+                           .collect();
+        Arena {
+            nodes: coerced,
+            root: arena.root().map(|id| NodeId::<FromNodeId>::from(id)),
+        }
+    }
+}
+
+#[cfg(test)]
+impl<T: Clone> From<Arena<T, FromNodeId>> for Arena<T, ToNodeId> {
+    fn from(arena: Arena<T, FromNodeId>) -> Self {
+        let coerced = arena.nodes
+                           .iter()
+                           .cloned()
+                           .map(|node| Node::<T, ToNodeId>::from(node))
+                           .collect();
+        Arena {
+            nodes: coerced,
+            root: arena.root().map(|id| NodeId::<ToNodeId>::from(id)),
+        }
+    }
+}
+
+impl<T: Clone, U: PartialEq + Copy> Arena<T, U> {
     /// Create an empty `Arena`.
-    pub fn new() -> Arena<T> {
+    pub fn new() -> Arena<T, U> {
         Default::default()
     }
 
@@ -152,7 +192,7 @@ impl<T: Clone> Arena<T> {
                     line_no: Option<usize>,
                     char_no: Option<usize>,
                     token_len: Option<usize>)
-                    -> NodeId {
+                    -> NodeId<U> {
         let next_id = NodeId::new(self.nodes.len());
         let mut node = Node::new(value, label, col_no, line_no, char_no, token_len);
         node.index = Some(next_id);
@@ -165,7 +205,7 @@ impl<T: Clone> Arena<T> {
 
     /// Create a new root node from its data.
     /// The new root has the previous root as its single child.
-    pub fn new_root(&mut self, new_root: NodeId) -> ArenaResult {
+    pub fn new_root(&mut self, new_root: NodeId<U>) -> ArenaResult {
         if self.root.is_none() {
             self.root = Some(new_root);
             return Ok(());
@@ -181,7 +221,7 @@ impl<T: Clone> Arena<T> {
     }
 
     /// Return root node.
-    pub fn root(&self) -> Option<NodeId> {
+    pub fn root(&self) -> Option<NodeId<U>> {
         self.root
     }
 
@@ -194,13 +234,13 @@ impl<T: Clone> Arena<T> {
     }
 
     /// Return `true` if index is in arena, `false` otherwise.
-    pub fn contains(&self, index: NodeId) -> bool {
+    pub fn contains(&self, index: NodeId<U>) -> bool {
         index.index < self.nodes.len()
     }
 
     /// Return a queue of `NodeId`s sorted by height.
-    pub fn get_priority_queue(&self) -> HeightQueue {
-        let mut queue = HeightQueue::new();
+    pub fn get_priority_queue(&self) -> HeightQueue<U> {
+        let mut queue = HeightQueue::<U>::new();
         for id in 0..self.size() {
             queue.push(NodeId::new(id), self);
         }
@@ -212,13 +252,13 @@ impl<T: Clone> Arena<T> {
     /// Each edge pair `(n1, n2)` denotes an edge between nodes `n1` and `n2`,
     /// both being `NodeId` indices within this arena. An edge within an `Arena`
     /// denotes a parent / child relationship between nodes.
-    pub fn get_edges(&self) -> Vec<EdgeId> {
-        let mut edges: Vec<EdgeId> = vec![];
+    pub fn get_edges(&self) -> Vec<EdgeId<U>> {
+        let mut edges: Vec<EdgeId<U>> = vec![];
         for index in 0..self.nodes.len() {
             let node = &self.nodes[index];
             match node.parent {
                 None => (),
-                Some(par) => edges.push((par, NodeId { index })),
+                Some(par) => edges.push((par, NodeId::<U>::new(index))),
             }
         }
         edges
@@ -226,7 +266,7 @@ impl<T: Clone> Arena<T> {
 }
 
 // Should have similar output as lrpar::parser::Node<TokId>::pretty_print().
-impl<T: fmt::Debug + Clone> fmt::Debug for Arena<T> {
+impl<T: fmt::Debug + Clone, U: PartialEq + Copy> fmt::Debug for Arena<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.nodes.is_empty() {
             // Case where self.root is None.
@@ -238,10 +278,10 @@ impl<T: fmt::Debug + Clone> fmt::Debug for Arena<T> {
         while !stack.is_empty() {
             let (indent, id) = stack.pop().unwrap();
             let node = &self.nodes[id.index];
-                for _ in 0..indent {
-                    formatted.push_str("  ");
-                }
-                formatted.push_str(&format!("{:?}\n", node));
+            for _ in 0..indent {
+                formatted.push_str("  ");
+            }
+            formatted.push_str(&format!("{:?}\n", node));
             if !id.is_leaf(self) {
                 // Non-terminal node.
                 let first_child = node.first_child.unwrap();
@@ -262,18 +302,18 @@ impl<T: fmt::Debug + Clone> fmt::Debug for Arena<T> {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
 /// An AST node within an `Arena`.
-pub struct Node<T: Clone> {
-    parent: Option<NodeId>,
-    previous_sibling: Option<NodeId>,
-    next_sibling: Option<NodeId>,
-    first_child: Option<NodeId>,
-    last_child: Option<NodeId>,
+#[derive(Clone, PartialEq, Eq)]
+pub struct Node<T: Clone, U: PartialEq + Copy> {
+    parent: Option<NodeId<U>>,
+    previous_sibling: Option<NodeId<U>>,
+    next_sibling: Option<NodeId<U>>,
+    first_child: Option<NodeId<U>>,
+    last_child: Option<NodeId<U>>,
     /// Index of this node in the arena.
     ///
     /// Note that nodes with a non-`None` index are unique.
-    index: Option<NodeId>,
+    index: Option<NodeId<U>>,
     /// The `value` of a node is the lexeme it corresponds to in the code.
     ///
     /// For example, a numerical or string literal, bracket, semicolon, etc.
@@ -302,7 +342,49 @@ pub struct Node<T: Clone> {
     pub token_len: Option<usize>,
 }
 
-impl<T: Clone> Node<T> {
+#[cfg(test)]
+impl<T: Clone> From<Node<T, ToNodeId>> for Node<T, FromNodeId> {
+    fn from(node: Node<T, ToNodeId>) -> Self {
+        Node::<T, FromNodeId> {
+            parent: node.parent().map(|id| NodeId::<FromNodeId>::from(id)),
+            previous_sibling: node.previous_sibling()
+                                  .map(|id| NodeId::<FromNodeId>::from(id)),
+            next_sibling: node.next_sibling().map(|id| NodeId::<FromNodeId>::from(id)),
+            first_child: node.first_child().map(|id| NodeId::<FromNodeId>::from(id)),
+            last_child: node.last_child().map(|id| NodeId::<FromNodeId>::from(id)),
+            index: node.index.map(|id| NodeId::<FromNodeId>::from(id)),
+            value: node.value,
+            label: node.label,
+            col_no: node.col_no,
+            line_no: node.line_no,
+            char_no: node.char_no,
+            token_len: node.token_len,
+        }
+    }
+}
+
+#[cfg(test)]
+impl<T: Clone> From<Node<T, FromNodeId>> for Node<T, ToNodeId> {
+    fn from(node: Node<T, FromNodeId>) -> Self {
+        Node::<T, ToNodeId> {
+            parent: node.parent().map(|id| NodeId::<ToNodeId>::from(id)),
+            previous_sibling: node.previous_sibling()
+                                  .map(|id| NodeId::<ToNodeId>::from(id)),
+            next_sibling: node.next_sibling().map(|id| NodeId::<ToNodeId>::from(id)),
+            first_child: node.first_child().map(|id| NodeId::<ToNodeId>::from(id)),
+            last_child: node.last_child().map(|id| NodeId::<ToNodeId>::from(id)),
+            index: node.index.map(|id| NodeId::<ToNodeId>::from(id)),
+            value: node.value,
+            label: node.label,
+            col_no: node.col_no,
+            line_no: node.line_no,
+            char_no: node.char_no,
+            token_len: node.token_len,
+        }
+    }
+}
+
+impl<T: Clone, U: PartialEq + Copy> Node<T, U> {
     /// Create a new node, with data, but without a parent or children.
     pub fn new(value: T,
                label: String,
@@ -310,7 +392,7 @@ impl<T: Clone> Node<T> {
                line_no: Option<usize>,
                char_no: Option<usize>,
                token_len: Option<usize>)
-               -> Node<T> {
+               -> Node<T, U> {
         Node {
             parent: None,
             previous_sibling: None,
@@ -328,46 +410,69 @@ impl<T: Clone> Node<T> {
     }
 
     /// Return the Id of the parent node, if there is one.
-    pub fn parent(&self) -> Option<NodeId> {
+    pub fn parent(&self) -> Option<NodeId<U>> {
         self.parent
     }
 
     /// Return the Id of the first child of this node, if there is one.
-    pub fn first_child(&self) -> Option<NodeId> {
+    pub fn first_child(&self) -> Option<NodeId<U>> {
         self.first_child
     }
 
     /// Return the Id of the last child of this node, if there is one.
-    pub fn last_child(&self) -> Option<NodeId> {
+    pub fn last_child(&self) -> Option<NodeId<U>> {
         self.last_child
     }
 
     /// Return the Id of the previous sibling of this node, if there is one.
-    pub fn previous_sibling(&self) -> Option<NodeId> {
+    pub fn previous_sibling(&self) -> Option<NodeId<U>> {
         self.previous_sibling
     }
 
     /// Return the Id of the previous sibling of this node, if there is one.
-    pub fn next_sibling(&self) -> Option<NodeId> {
+    pub fn next_sibling(&self) -> Option<NodeId<U>> {
         self.next_sibling
     }
 }
 
-impl<T: fmt::Debug + Clone> fmt::Debug for Node<T> {
+impl<T: fmt::Debug + Clone, U: PartialEq + Copy> fmt::Debug for Node<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let value_s = format!(" {:?}", self.value);
         // Avoid empty, escaped quotes in output.
-        if value_s == String::from(" \"\"") {
+        if value_s == " \"\"" {
             return write!(f, "{}", self.label);
         }
         write!(f, "{}{}", self.label, value_s)
     }
 }
 
-impl NodeId {
+impl<T: PartialEq + Copy> fmt::Debug for NodeId<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NodeId {{ index: {} }}", self.index)
+    }
+}
+
+#[cfg(test)]
+impl From<NodeId<FromNodeId>> for NodeId<ToNodeId> {
+    fn from(id: NodeId<FromNodeId>) -> Self {
+        NodeId::<ToNodeId>::new(id.index)
+    }
+}
+
+#[cfg(test)]
+impl From<NodeId<ToNodeId>> for NodeId<FromNodeId> {
+    fn from(id: NodeId<ToNodeId>) -> Self {
+        NodeId::<FromNodeId>::new(id.index)
+    }
+}
+
+impl<U: PartialEq + Copy> NodeId<U> {
     /// Create a new NodeId with a given index.
-    pub fn new(index: usize) -> NodeId {
-        NodeId { index: index }
+    pub fn new(index: usize) -> NodeId<U> {
+        NodeId {
+            index: index,
+            phantom: PhantomData,
+        }
     }
 
     /// Return the index of this Node Id.
@@ -376,7 +481,7 @@ impl NodeId {
     }
 
     /// `true` if this node has no children.
-    pub fn is_leaf<T: Clone>(&self, arena: &Arena<T>) -> bool {
+    pub fn is_leaf<T: Clone>(&self, arena: &Arena<T, U>) -> bool {
         arena[*self].first_child.is_none()
     }
 
@@ -384,7 +489,7 @@ impl NodeId {
     ///
     /// If a node has been added to the arena without being given a parent, or
     /// a node has been detached from its parent, this method will return `true`.
-    pub fn is_root<T: Clone>(&self, arena: &Arena<T>) -> bool {
+    pub fn is_root<T: Clone>(&self, arena: &Arena<T, U>) -> bool {
         arena[*self].parent.is_none()
     }
 
@@ -392,7 +497,7 @@ impl NodeId {
     ///
     /// The height of a leaf node is 1, the height of a branch node is 1 +
     /// the height of its tallest child node.
-    pub fn height<T: Clone>(&self, arena: &Arena<T>) -> u32 {
+    pub fn height<T: Clone>(&self, arena: &Arena<T, U>) -> u32 {
         if self.is_leaf(arena) {
             return 1;
         }
@@ -408,7 +513,7 @@ impl NodeId {
     /// actually removed from the arena, because `NodeId`s should be immutable.
     /// This means that if you detach the root of the tree, any iterator will
     /// still be able to reach the root (but not any of the other nodes).
-    pub fn detach<T: Clone>(&self, arena: &mut Arena<T>) -> ArenaResult {
+    pub fn detach<T: Clone>(&self, arena: &mut Arena<T, U>) -> ArenaResult {
         if !arena.contains(*self) {
             return Err(ArenaError::NodeIdNotFound);
         }
@@ -435,9 +540,9 @@ impl NodeId {
     /// actually removed from the arena, because `NodeId`s should be immutable.
     /// This means that if you detach the root of the tree, any iterator will
     /// still be able to reach the root (but not any of the other nodes).
-    pub fn detach_with_children<T: Clone>(&self, arena: &mut Arena<T>) -> ArenaResult {
+    pub fn detach_with_children<T: Clone>(&self, arena: &mut Arena<T, U>) -> ArenaResult {
         self.detach(arena)?;
-        let ids = self.children(arena).collect::<Vec<NodeId>>();
+        let ids = self.children(arena).collect::<Vec<NodeId<U>>>();
         for id in ids {
             id.detach_with_children(arena)?;
         }
@@ -445,7 +550,10 @@ impl NodeId {
     }
 
     /// Make self the next (i.e. last) child of another.
-    pub fn make_child_of<T: Clone>(&self, parent: NodeId, arena: &mut Arena<T>) -> ArenaResult {
+    pub fn make_child_of<T: Clone>(&self,
+                                   parent: NodeId<U>,
+                                   arena: &mut Arena<T, U>)
+                                   -> ArenaResult {
         if self.index >= arena.size() || parent.index >= arena.size() {
             return Err(ArenaError::NodeIdNotFound);
         }
@@ -470,9 +578,9 @@ impl NodeId {
     /// Children are numbered from zero, so `nth == 0` makes `self` the *first*
     /// child of `parent`.
     pub fn make_nth_child_of<T: Clone>(&mut self,
-                                       parent: NodeId,
+                                       parent: NodeId<U>,
                                        nth: u16,
-                                       arena: &mut Arena<T>)
+                                       arena: &mut Arena<T, U>)
                                        -> ArenaResult {
         if !arena.contains(*self) {
             return Err(ArenaError::NodeIdNotFound);
@@ -484,7 +592,7 @@ impl NodeId {
             // Make self the *first* child of parent.
             return self.make_child_of(parent, arena);
         }
-        let children = parent.children(arena).collect::<Vec<NodeId>>();
+        let children = parent.children(arena).collect::<Vec<NodeId<U>>>();
         let n_children = children.len() as u16;
         if nth == children.len() as u16 {
             // Make self the *last* child of parent.
@@ -515,7 +623,7 @@ impl NodeId {
     }
 
     /// If `self` is the *nth* child of its parent, return *n*.
-    pub fn get_child_position<T: Clone>(self, arena: &Arena<T>) -> Option<usize> {
+    pub fn get_child_position<T: Clone>(self, arena: &Arena<T, U>) -> Option<usize> {
         if arena[self].parent.is_none() {
             return None;
         }
@@ -527,7 +635,7 @@ impl NodeId {
     }
 
     /// Return an iterator of references to this node’s children.
-    pub fn children<T: Clone>(self, arena: &Arena<T>) -> Children<T> {
+    pub fn children<T: Clone>(self, arena: &Arena<T, U>) -> Children<T, U> {
         Children {
             arena: arena,
             node: arena[self].first_child,
@@ -535,7 +643,7 @@ impl NodeId {
     }
 
     /// Return an iterator of references to this node’s children, in reverse order.
-    pub fn reverse_children<T: Clone>(self, arena: &Arena<T>) -> ReverseChildren<T> {
+    pub fn reverse_children<T: Clone>(self, arena: &Arena<T, U>) -> ReverseChildren<T, U> {
         ReverseChildren {
             arena: arena,
             node: arena[self].last_child,
@@ -543,7 +651,9 @@ impl NodeId {
     }
 
     /// Return a breadth-first iterator of references to this node's descendants.
-    pub fn breadth_first_traversal<T: Clone>(self, arena: &Arena<T>) -> BreadthFirstTraversal<T> {
+    pub fn breadth_first_traversal<T: Clone>(self,
+                                             arena: &Arena<T, U>)
+                                             -> BreadthFirstTraversal<T, U> {
         let mut queue = VecDeque::new();
         queue.push_back(self);
         BreadthFirstTraversal {
@@ -553,7 +663,7 @@ impl NodeId {
     }
 
     /// Return a post-order iterator of references to this node's descendants.
-    pub fn post_order_traversal<T: Clone>(self, arena: &Arena<T>) -> PostOrderTraversal<T> {
+    pub fn post_order_traversal<T: Clone>(self, arena: &Arena<T, U>) -> PostOrderTraversal<T, U> {
         let mut stack1 = VecDeque::new();
         stack1.push_front(self);
         PostOrderTraversal {
@@ -564,7 +674,7 @@ impl NodeId {
     }
 
     /// Return a pre-order iterator of references to this node's descendants.
-    pub fn pre_order_traversal<T: Clone>(self, arena: &Arena<T>) -> PreOrderTraversal<T> {
+    pub fn pre_order_traversal<T: Clone>(self, arena: &Arena<T, U>) -> PreOrderTraversal<T, U> {
         let mut stack = VecDeque::new();
         stack.push_front(self);
         PreOrderTraversal {
@@ -574,7 +684,7 @@ impl NodeId {
     }
 
     /// Get the descendants of this node, without including the node itself.
-    pub fn descendants<T: Clone>(self, arena: &Arena<T>) -> PreOrderTraversal<T> {
+    pub fn descendants<T: Clone>(self, arena: &Arena<T, U>) -> PreOrderTraversal<T, U> {
         let mut stack = VecDeque::new();
         stack.push_front(self);
         let mut iterator = PreOrderTraversal {
@@ -588,9 +698,9 @@ impl NodeId {
 
 macro_rules! impl_node_iterator {
     ($name: ident, $next: expr) => {
-        impl<'a, T: Clone> Iterator for $name<'a, T> {
-            type Item = NodeId;
-            fn next(&mut self) -> Option<NodeId> {
+        impl<'a, T: Clone, U: PartialEq + Copy> Iterator for $name<'a, T, U> {
+            type Item = NodeId<U>;
+            fn next(&mut self) -> Option<NodeId<U>> {
                 match self.node.take() {
                     Some(node) => {
                         self.node = $next(&self.arena[node]);
@@ -604,28 +714,28 @@ macro_rules! impl_node_iterator {
 }
 
 /// An iterator of references to the children of a given node.
-pub struct Children<'a, T: Clone + 'a> {
-    arena: &'a Arena<T>,
-    node: Option<NodeId>,
+pub struct Children<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
+    arena: &'a Arena<T, U>,
+    node: Option<NodeId<U>>,
 }
-impl_node_iterator!(Children, |node: &Node<T>| node.next_sibling);
+impl_node_iterator!(Children, |node: &Node<T, U>| node.next_sibling);
 
 /// An iterator of references to the children of a given node.
-pub struct ReverseChildren<'a, T: Clone + 'a> {
-    arena: &'a Arena<T>,
-    node: Option<NodeId>,
+pub struct ReverseChildren<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
+    arena: &'a Arena<T, U>,
+    node: Option<NodeId<U>>,
 }
-impl_node_iterator!(ReverseChildren, |node: &Node<T>| node.previous_sibling);
+impl_node_iterator!(ReverseChildren, |node: &Node<T, U>| node.previous_sibling);
 
 /// A breadth-first iterator of references to the descendants of a given node.
-pub struct BreadthFirstTraversal<'a, T: Clone + 'a> {
-    arena: &'a Arena<T>,
-    queue: VecDeque<NodeId>,
+pub struct BreadthFirstTraversal<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
+    arena: &'a Arena<T, U>,
+    queue: VecDeque<NodeId<U>>,
 }
 
-impl<'a, T: Clone> Iterator for BreadthFirstTraversal<'a, T> {
-    type Item = NodeId;
-    fn next(&mut self) -> Option<NodeId> {
+impl<'a, T: Clone, U: PartialEq + Copy> Iterator for BreadthFirstTraversal<'a, T, U> {
+    type Item = NodeId<U>;
+    fn next(&mut self) -> Option<NodeId<U>> {
         match self.queue.pop_front() {
             Some(node) => {
                 for child in node.children(self.arena) {
@@ -639,16 +749,16 @@ impl<'a, T: Clone> Iterator for BreadthFirstTraversal<'a, T> {
 }
 
 /// A post-order iterator of references to the descendants of a given node.
-pub struct PostOrderTraversal<'a, T: Clone + 'a> {
-    arena: &'a Arena<T>,
-    stack1: VecDeque<NodeId>,
-    stack2: VecDeque<NodeId>,
+pub struct PostOrderTraversal<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
+    arena: &'a Arena<T, U>,
+    stack1: VecDeque<NodeId<U>>,
+    stack2: VecDeque<NodeId<U>>,
 }
 
-impl<'a, T: Clone> Iterator for PostOrderTraversal<'a, T> {
-    type Item = NodeId;
-    fn next(&mut self) -> Option<NodeId> {
-        let mut current: NodeId;
+impl<'a, T: Clone, U: PartialEq + Copy> Iterator for PostOrderTraversal<'a, T, U> {
+    type Item = NodeId<U>;
+    fn next(&mut self) -> Option<NodeId<U>> {
+        let mut current: NodeId<U>;
         while !self.stack1.is_empty() {
             current = self.stack1.pop_front().unwrap();
             self.stack2.push_front(current);
@@ -661,14 +771,14 @@ impl<'a, T: Clone> Iterator for PostOrderTraversal<'a, T> {
 }
 
 /// A pre-order iterator of references to the descendants of a given node.
-pub struct PreOrderTraversal<'a, T: Clone + 'a> {
-    arena: &'a Arena<T>,
-    stack: VecDeque<NodeId>,
+pub struct PreOrderTraversal<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
+    arena: &'a Arena<T, U>,
+    stack: VecDeque<NodeId<U>>,
 }
 
-impl<'a, T: Clone> Iterator for PreOrderTraversal<'a, T> {
-    type Item = NodeId;
-    fn next(&mut self) -> Option<NodeId> {
+impl<'a, T: Clone, U: PartialEq + Copy> Iterator for PreOrderTraversal<'a, T, U> {
+    type Item = NodeId<U>;
+    fn next(&mut self) -> Option<NodeId<U>> {
         if self.stack.is_empty() {
             return None;
         }
@@ -681,17 +791,17 @@ impl<'a, T: Clone> Iterator for PreOrderTraversal<'a, T> {
 }
 
 // Turn a grammar, parser and input string into an AST arena.
-fn parse_into_ast(pt: &parser::Node<u16>,
-                  lexer: &Lexer<u16>,
-                  grm: &YaccGrammar,
-                  input: &str)
-                  -> Arena<String> {
+fn parse_into_ast<T: PartialEq + Copy>(pt: &parser::Node<u16>,
+                                       lexer: &Lexer<u16>,
+                                       grm: &YaccGrammar,
+                                       input: &str)
+                                       -> Arena<String, T> {
     let mut arena = Arena::new();
     let mut st = vec![pt]; // Stack of nodes.
     // Stack of `Option<NodeId>`s which are parents of nodes on the `st` stack.
     // The stack should never be empty, a `None` should be at the bottom of the stack.
     let mut parent = vec![None];
-    let mut child_node: NodeId;
+    let mut child_node: NodeId<T>;
     while !st.is_empty() {
         let e = st.pop().unwrap();
         match *e {
@@ -719,7 +829,7 @@ fn parse_into_ast(pt: &parser::Node<u16>,
             } => {
                 // A non-terminal has no value of its own, but has a node type.
                 child_node = arena.new_node("".to_string(),
-                                            grm.nonterm_name(nonterm_idx).unwrap().to_string(),
+                                            grm.nonterm_name(nonterm_idx).to_string(),
                                             None,
                                             None,
                                             None,
@@ -753,10 +863,10 @@ fn read_file(path: &Path) -> Result<String, ParseError> {
 }
 
 /// Parse an individual input file, and return an `Arena` or `ParseError`.
-pub fn parse_file(input_path: &str,
-                  lex_path: &Path,
-                  yacc_path: &Path)
-                  -> Result<Arena<String>, ParseError> {
+pub fn parse_file<T: PartialEq + Copy>(input_path: &str,
+                                       lex_path: &Path,
+                                       yacc_path: &Path)
+                                       -> Result<Arena<String, T>, ParseError> {
     // Determine lexer and yacc files by extension. For example if the input
     // file is named Foo.java, the lexer should be grammars/java.l.
     // TODO: create a HashMap of file extensions -> lex/yacc files.
@@ -774,9 +884,9 @@ pub fn parse_file(input_path: &str,
 
     // Sync up the IDs of terminals in the lexer and parser.
     let rule_ids = grm.terms_map()
-        .iter()
-        .map(|(&n, &i)| (n, u16::try_from(usize::from(i)).unwrap()))
-        .collect();
+                      .iter()
+                      .map(|(&n, &i)| (n, u16::try_from(usize::from(i)).unwrap()))
+                      .collect();
     lexerdef.set_rule_ids(&rule_ids);
 
     // Lex input file.
@@ -786,15 +896,55 @@ pub fn parse_file(input_path: &str,
     // Return parse tree.
     let pt = parser::parse::<u16>(&grm, &sgraph, &stable, &lexemes)
         .map_err(|_| ParseError::SyntaxError)?;
-    Ok(parse_into_ast(&pt, &lexer, &grm, &input))
+    Ok(parse_into_ast::<T>(&pt, &lexer, &grm, &input))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn create_arena() -> Arena<String> {
-        let mut arena = Arena::new();
+    #[test]
+    fn from_trait_node_ids() {
+        let from = NodeId::<FromNodeId>::new(100);
+        let to = NodeId::<ToNodeId>::new(200);
+        assert_eq!(NodeId::<FromNodeId>::from(to).index, to.index);
+        assert_eq!(NodeId::<ToNodeId>::from(from).index, from.index);
+    }
+
+    #[test]
+    fn from_trait_nodes() {
+        let mut arena_from = Arena::<&str, FromNodeId>::new();
+        let _root_from =
+            arena_from.new_node("class", String::from("CLASS"), None, None, None, None);
+        let nodeid_from =
+            arena_from.new_node("private", String::from("MODIFIER"), None, None, None, None);
+        let mut arena_to = Arena::<&str, ToNodeId>::new();
+        let _root_to = arena_to.new_node("", String::from("EXPR"), None, None, None, None);
+        let nodeid_to = arena_to.new_node("*", String::from("MULT"), None, None, None, None);
+        let coerced_from = Node::<&str, FromNodeId>::from(arena_to[nodeid_to].clone());
+        assert_eq!(arena_from[nodeid_from].index, coerced_from.index);
+        assert_eq!(arena_from[nodeid_from].parent(), coerced_from.parent());
+        assert_eq!(arena_from[nodeid_from].first_child(),
+                   coerced_from.first_child());
+        assert_eq!(arena_from[nodeid_from].last_child(),
+                   coerced_from.last_child());
+        assert_eq!(arena_from[nodeid_from].previous_sibling(),
+                   coerced_from.previous_sibling());
+        assert_eq!(arena_from[nodeid_from].next_sibling(),
+                   coerced_from.next_sibling());
+        let coerced_to = Node::<&str, ToNodeId>::from(arena_from[nodeid_from].clone());
+        assert_eq!(arena_to[nodeid_to].index, coerced_to.index);
+        assert_eq!(arena_to[nodeid_to].parent(), coerced_to.parent());
+        assert_eq!(arena_to[nodeid_to].first_child(), coerced_to.first_child());
+        assert_eq!(arena_to[nodeid_to].last_child(), coerced_to.last_child());
+        assert_eq!(arena_to[nodeid_to].previous_sibling(),
+                   coerced_to.previous_sibling());
+        assert_eq!(arena_to[nodeid_to].next_sibling(),
+                   coerced_to.next_sibling());
+    }
+
+    fn create_arena() -> Arena<String, FromNodeId> {
+        let mut arena = Arena::<String, FromNodeId>::new();
         let root = arena.new_node(String::from("+"),
                                   String::from("Expr"),
                                   None,
@@ -833,8 +983,29 @@ mod tests {
     }
 
     #[test]
+    fn from_trait_arenas() {
+        let from_arena = create_arena();
+        let coerced_to_arena = Arena::<String, ToNodeId>::from(from_arena.clone());
+        let coerced_from_arena = Arena::<String, FromNodeId>::from(coerced_to_arena.clone());
+        let format = "Expr \"+\"
+  INT \"1\"
+  Expr \"*\"
+    INT \"3\"
+    INT \"4\"
+";
+        assert_eq!(format, format!("{:?}", from_arena));
+        assert_eq!(format, format!("{:?}", coerced_to_arena));
+        assert_eq!(format, format!("{:?}", coerced_from_arena));
+        assert!(from_arena.root().is_some());
+        assert_eq!(from_arena.root(),
+                   coerced_to_arena.root()
+                                   .map(|id| NodeId::<FromNodeId>::from(id)));
+        assert_eq!(from_arena.root(), coerced_from_arena.root());
+    }
+
+    #[test]
     fn new_ast_node() {
-        let arena = &mut Arena::new();
+        let arena = &mut Arena::<&str, FromNodeId>::new();
         assert!(arena.is_empty());
         let n0 = arena.new_node("100", String::from("INT"), None, None, None, None);
         assert!(arena[n0].index != None);
@@ -882,7 +1053,7 @@ mod tests {
 
     #[test]
     fn make_child_of_2() {
-        let mut arena = Arena::new();
+        let mut arena = Arena::<&str, FromNodeId>::new();
         assert!(arena.is_empty());
         let root = arena.new_node("+", String::from("Expr"), None, None, None, None);
         assert!(!arena.is_empty());
@@ -918,7 +1089,7 @@ mod tests {
 
     #[test]
     fn make_nth_child_of_1() {
-        let mut arena = Arena::new();
+        let mut arena = Arena::<&str, FromNodeId>::new();
         let root = arena.new_node("+", String::from("Expr"), None, None, None, None);
         assert!(!arena.is_empty());
         let n1 = arena.new_node("1", String::from("INT"), None, None, None, None);
@@ -944,7 +1115,7 @@ mod tests {
 
     #[test]
     fn make_nth_child_of_2() {
-        let mut arena = Arena::new();
+        let mut arena = Arena::<&str, FromNodeId>::new();
         let root = arena.new_node("+", String::from("Expr"), None, None, None, None);
         assert!(!arena.is_empty());
         let n1 = arena.new_node("1", String::from("INT"), None, None, None, None);
@@ -970,7 +1141,7 @@ mod tests {
 
     #[test]
     fn make_nth_child_of_3() {
-        let mut arena = Arena::new();
+        let mut arena = Arena::<&str, FromNodeId>::new();
         let root = arena.new_node("+", String::from("Expr"), None, None, None, None);
         assert!(!arena.is_empty());
         let n1 = arena.new_node("1", String::from("INT"), None, None, None, None);
@@ -996,27 +1167,23 @@ mod tests {
 
     #[test]
     fn node_fmt() {
-        let n1 = Node::new("private",
-                           String::from("MODIFIER"),
-                           None,
-                           None,
-                           None,
-                           None);
+        let n1 = Node::<&str, NodeId<FromNodeId>>::new("private",
+                                                       String::from("MODIFIER"),
+                                                       None,
+                                                       None,
+                                                       None,
+                                                       None);
         let expected1 = "MODIFIER \"private\"";
         assert_eq!(expected1, format!("{:?}", n1));
-        let n2 = Node::new("",
-                           String::from("Expr"),
-                           None,
-                           None,
-                           None,
-                           None);
+        let n2 =
+            Node::<&str, NodeId<FromNodeId>>::new("", String::from("Expr"), None, None, None, None);
         let expected2 = "Expr";
         assert_eq!(expected2, format!("{:?}", n2));
     }
 
     #[test]
     fn arena_fmt_debug() {
-        let mut arena = Arena::new();
+        let mut arena = Arena::<&str, NodeId<FromNodeId>>::new();
         let root = arena.new_node("+", String::from("Expr"), None, None, None, None);
         let n1 = arena.new_node("1", String::from("INT"), None, None, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
@@ -1031,27 +1198,27 @@ mod tests {
 
     #[test]
     fn get_edges_1() {
-        let arena: Arena<String> = Arena::new();
+        let arena: Arena<String, FromNodeId> = Arena::new();
         assert!(arena.is_empty());
-        let edges: Vec<EdgeId> = vec![];
+        let edges: Vec<EdgeId<FromNodeId>> = vec![];
         assert_eq!(edges, arena.get_edges());
     }
 
     #[test]
     fn get_edges_2() {
-        let arena = &mut Arena::new();
+        let arena = &mut Arena::<&str, FromNodeId>::new();
         arena.new_node("1", String::from("INT"), None, None, None, None);
-        let edges: Vec<EdgeId> = vec![];
+        let edges: Vec<EdgeId<FromNodeId>> = vec![];
         assert_eq!(edges, arena.get_edges());
     }
 
     #[test]
     fn get_edges_3() {
         let arena = create_arena();
-        let edges: Vec<EdgeId> = vec![(NodeId::new(0), NodeId::new(1)),
-                                      (NodeId::new(0), NodeId::new(2)),
-                                      (NodeId::new(2), NodeId::new(3)),
-                                      (NodeId::new(2), NodeId::new(4))];
+        let edges: Vec<EdgeId<FromNodeId>> = vec![(NodeId::new(0), NodeId::new(1)),
+                                                  (NodeId::new(0), NodeId::new(2)),
+                                                  (NodeId::new(2), NodeId::new(3)),
+                                                  (NodeId::new(2), NodeId::new(4))];
         assert_eq!(edges, arena.get_edges());
     }
 
@@ -1096,15 +1263,29 @@ mod tests {
         let root = NodeId::new(0);
         let n2 = NodeId::new(2);
         // Children of root.
-        let expected1: Vec<NodeId> = vec![NodeId { index: 1 }, NodeId { index: 2 }];
-        let root_child_ids = root.children(&arena).collect::<Vec<NodeId>>();
+        let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId {
+                                                          index: 1,
+                                                          phantom: PhantomData,
+                                                      },
+                                                      NodeId {
+                                                          index: 2,
+                                                          phantom: PhantomData,
+                                                      }];
+        let root_child_ids = root.children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected1.len(), root_child_ids.len());
         for index in 0..expected1.len() {
             assert_eq!(expected1[index], root_child_ids[index]);
         }
         // Children of n2.
-        let expected2: Vec<NodeId> = vec![NodeId { index: 3 }, NodeId { index: 4 }];
-        let n2_child_ids = n2.children(&arena).collect::<Vec<NodeId>>();
+        let expected2: Vec<NodeId<FromNodeId>> = vec![NodeId {
+                                                          index: 3,
+                                                          phantom: PhantomData,
+                                                      },
+                                                      NodeId {
+                                                          index: 4,
+                                                          phantom: PhantomData,
+                                                      }];
+        let n2_child_ids = n2.children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected2.len(), n2_child_ids.len());
         for index in 0..expected2.len() {
             assert_eq!(expected2[index], n2_child_ids[index]);
@@ -1117,15 +1298,31 @@ mod tests {
         let root = NodeId::new(0);
         let n2 = NodeId::new(2);
         // Children of root.
-        let expected1: Vec<NodeId> = vec![NodeId { index: 2 }, NodeId { index: 1 }];
-        let root_child_ids = root.reverse_children(&arena).collect::<Vec<NodeId>>();
+        let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId {
+                                                          index: 2,
+                                                          phantom: PhantomData,
+                                                      },
+                                                      NodeId {
+                                                          index: 1,
+                                                          phantom: PhantomData,
+                                                      }];
+        let root_child_ids = root.reverse_children(&arena)
+                                 .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected1.len(), root_child_ids.len());
         for index in 0..expected1.len() {
             assert_eq!(expected1[index], root_child_ids[index]);
         }
         // Children of n2.
-        let expected2: Vec<NodeId> = vec![NodeId { index: 4 }, NodeId { index: 3 }];
-        let n2_child_ids = n2.reverse_children(&arena).collect::<Vec<NodeId>>();
+        let expected2: Vec<NodeId<FromNodeId>> = vec![NodeId {
+                                                          index: 4,
+                                                          phantom: PhantomData,
+                                                      },
+                                                      NodeId {
+                                                          index: 3,
+                                                          phantom: PhantomData,
+                                                      }];
+        let n2_child_ids = n2.reverse_children(&arena)
+                             .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected2.len(), n2_child_ids.len());
         for index in 0..expected2.len() {
             assert_eq!(expected2[index], n2_child_ids[index]);
@@ -1136,23 +1333,24 @@ mod tests {
     fn breadth_first_traversal() {
         let arena = create_arena();
         // Descendants  of root.
-        let expected1: Vec<NodeId> = vec![NodeId::new(0),
-                                          NodeId::new(1),
-                                          NodeId::new(2),
-                                          NodeId::new(3),
-                                          NodeId::new(4)];
+        let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId::new(0),
+                                                      NodeId::new(1),
+                                                      NodeId::new(2),
+                                                      NodeId::new(3),
+                                                      NodeId::new(4)];
         let descendants1 = NodeId::new(0)
             .breadth_first_traversal(&arena)
-            .collect::<Vec<NodeId>>();
+            .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected1.len(), descendants1.len());
         for index in 0..expected1.len() {
             assert_eq!(expected1[index], descendants1[index]);
         }
         // Descendants of n2.
-        let expected2: Vec<NodeId> = vec![NodeId::new(2), NodeId::new(3), NodeId::new(4)];
+        let expected2: Vec<NodeId<FromNodeId>> =
+            vec![NodeId::new(2), NodeId::new(3), NodeId::new(4)];
         let descendants2 = NodeId::new(2)
             .breadth_first_traversal(&arena)
-            .collect::<Vec<NodeId>>();
+            .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected2.len(), descendants2.len());
         for index in 0..expected2.len() {
             assert_eq!(expected2[index], descendants2[index]);
@@ -1163,23 +1361,24 @@ mod tests {
     fn post_order_traversal() {
         let arena = create_arena();
         // Descendants  of root.
-        let expected1: Vec<NodeId> = vec![NodeId::new(1),
-                                          NodeId::new(3),
-                                          NodeId::new(4),
-                                          NodeId::new(2),
-                                          NodeId::new(0)];
+        let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId::new(1),
+                                                      NodeId::new(3),
+                                                      NodeId::new(4),
+                                                      NodeId::new(2),
+                                                      NodeId::new(0)];
         let descendants1 = NodeId::new(0)
             .post_order_traversal(&arena)
-            .collect::<Vec<NodeId>>();
+            .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected1.len(), descendants1.len());
         for index in 0..expected1.len() {
             assert_eq!(expected1[index], descendants1[index]);
         }
         // Descendants of n2.
-        let expected2: Vec<NodeId> = vec![NodeId::new(3), NodeId::new(4), NodeId::new(2)];
+        let expected2: Vec<NodeId<FromNodeId>> =
+            vec![NodeId::new(3), NodeId::new(4), NodeId::new(2)];
         let descendants2 = NodeId::new(2)
             .post_order_traversal(&arena)
-            .collect::<Vec<NodeId>>();
+            .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected2.len(), descendants2.len());
         for index in 0..expected2.len() {
             assert_eq!(expected2[index], descendants2[index]);
@@ -1190,23 +1389,24 @@ mod tests {
     fn pre_order_traversal() {
         let arena = create_arena();
         // Descendants  of root.
-        let expected1: Vec<NodeId> = vec![NodeId::new(0),
-                                          NodeId::new(1),
-                                          NodeId::new(2),
-                                          NodeId::new(3),
-                                          NodeId::new(4)];
+        let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId::new(0),
+                                                      NodeId::new(1),
+                                                      NodeId::new(2),
+                                                      NodeId::new(3),
+                                                      NodeId::new(4)];
         let descendants1 = NodeId::new(0)
             .pre_order_traversal(&arena)
-            .collect::<Vec<NodeId>>();
+            .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected1.len(), descendants1.len());
         for index in 0..expected1.len() {
             assert_eq!(expected1[index], descendants1[index]);
         }
         // Descendants of n2.
-        let expected2: Vec<NodeId> = vec![NodeId::new(2), NodeId::new(3), NodeId::new(4)];
+        let expected2: Vec<NodeId<FromNodeId>> =
+            vec![NodeId::new(2), NodeId::new(3), NodeId::new(4)];
         let descendants2 = NodeId::new(2)
             .pre_order_traversal(&arena)
-            .collect::<Vec<NodeId>>();
+            .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected2.len(), descendants2.len());
         for index in 0..expected2.len() {
             assert_eq!(expected2[index], descendants2[index]);
@@ -1217,18 +1417,22 @@ mod tests {
     fn descendants() {
         let arena = create_arena();
         // Descendants  of root.
-        let expected1: Vec<NodeId> = vec![NodeId::new(1),
-                                          NodeId::new(2),
-                                          NodeId::new(3),
-                                          NodeId::new(4)];
-        let descendants1 = NodeId::new(0).descendants(&arena).collect::<Vec<NodeId>>();
+        let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId::new(1),
+                                                      NodeId::new(2),
+                                                      NodeId::new(3),
+                                                      NodeId::new(4)];
+        let descendants1 = NodeId::new(0)
+            .descendants(&arena)
+            .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected1.len(), descendants1.len());
         for index in 0..expected1.len() {
             assert_eq!(expected1[index], descendants1[index]);
         }
         // Descendants of n2.
-        let expected2: Vec<NodeId> = vec![NodeId::new(3), NodeId::new(4)];
-        let descendants2 = NodeId::new(2).descendants(&arena).collect::<Vec<NodeId>>();
+        let expected2: Vec<NodeId<FromNodeId>> = vec![NodeId::new(3), NodeId::new(4)];
+        let descendants2 = NodeId::new(2)
+            .descendants(&arena)
+            .collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected2.len(), descendants2.len());
         for index in 0..expected2.len() {
             assert_eq!(expected2[index], descendants2[index]);
@@ -1237,15 +1441,18 @@ mod tests {
 
     #[test]
     fn contains() {
-        let arena = &mut Arena::new();
+        let arena = &mut Arena::<&str, FromNodeId>::new();
         let n1 = arena.new_node("1", String::from("INT"), None, None, None, None);
         assert!(arena.contains(n1));
-        assert!(!arena.contains(NodeId { index: 1 }));
+        assert!(!arena.contains(NodeId {
+                                    index: 1,
+                                    phantom: PhantomData,
+                                }));
     }
 
     #[test]
     fn size() {
-        let arena = &mut Arena::new();
+        let arena = &mut Arena::<&str, FromNodeId>::new();
         assert_eq!(0, arena.size());
         let _ = arena.new_node("+", String::from("Expr"), None, None, None, None);
         assert_eq!(1, arena.size());

--- a/src/lib/gt_matcher.rs
+++ b/src/lib/gt_matcher.rs
@@ -39,7 +39,7 @@
 
 use std::fmt::Debug;
 
-use ast::{Arena, NodeId};
+use ast::{Arena, FromNodeId, NodeId, ToNodeId};
 use matchers::{MappingStore, MappingType, MatchTrees};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -88,12 +88,14 @@ Code Differencing.";
     }
 
     /// Match locations in distinct ASTs.
-    fn match_trees(&self, base: Arena<T>, diff: Arena<T>) -> MappingStore<T> {
+    fn match_trees(&self, base: Arena<T, FromNodeId>, diff: Arena<T, ToNodeId>) -> MappingStore<T> {
         let mut store = MappingStore::new(base, diff);
         if store.from_arena.size() == 0 || store.to_arena.size() == 0 {
             return store;
         }
-        store.push(NodeId::new(0), NodeId::new(0), &MappingType::ANCHOR);
+        store.push(NodeId::<FromNodeId>::new(0),
+                   NodeId::<ToNodeId>::new(0),
+                   &MappingType::ANCHOR);
         store
     }
 }

--- a/src/lib/myers_matcher.rs
+++ b/src/lib/myers_matcher.rs
@@ -39,7 +39,7 @@
 
 use std::fmt::Debug;
 
-use ast::{Arena, NodeId};
+use ast::{Arena, FromNodeId, NodeId, ToNodeId};
 use matchers::{MappingStore, MappingType, MatchTrees};
 use sequence::lcss;
 
@@ -73,23 +73,21 @@ Variations.";
     }
 
     /// Match locations in distinct ASTs.
-    fn match_trees(&self, base: Arena<T>, diff: Arena<T>) -> MappingStore<T> {
+    fn match_trees(&self, base: Arena<T, FromNodeId>, diff: Arena<T, ToNodeId>) -> MappingStore<T> {
         let mut store = MappingStore::new(base, diff);
         if store.from_arena.is_empty() || store.to_arena.is_empty() {
             return store;
         }
-        let base_pre = store
-            .from_arena
-            .root()
-            .unwrap()
-            .pre_order_traversal(&store.from_arena)
-            .collect::<Vec<NodeId>>();
-        let diff_pre = store
-            .to_arena
-            .root()
-            .unwrap()
-            .pre_order_traversal(&store.to_arena)
-            .collect::<Vec<NodeId>>();
+        let base_pre = store.from_arena
+                            .root()
+                            .unwrap()
+                            .pre_order_traversal(&store.from_arena)
+                            .collect::<Vec<NodeId<FromNodeId>>>();
+        let diff_pre = store.to_arena
+                            .root()
+                            .unwrap()
+                            .pre_order_traversal(&store.to_arena)
+                            .collect::<Vec<NodeId<ToNodeId>>>();
 
         let longest = lcss(&base_pre,
                            &store.from_arena,
@@ -104,10 +102,10 @@ Variations.";
 }
 
 /// Test that two nodes have the same label and value.
-fn eq<T: Clone + Debug + Eq>(n1: &NodeId,
-                             arena1: &Arena<T>,
-                             n2: &NodeId,
-                             arena2: &Arena<T>)
+fn eq<T: Clone + Debug + Eq>(n1: &NodeId<FromNodeId>,
+                             arena1: &Arena<T, FromNodeId>,
+                             n2: &NodeId<ToNodeId>,
+                             arena2: &Arena<T, ToNodeId>)
                              -> bool {
     arena1[*n1].label == arena2[*n2].label && arena1[*n1].value == arena2[*n2].value
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,7 +237,10 @@ fn get_matcher_descriptions() -> String {
     descriptions.join("\n")
 }
 
-fn parse_file(filename: &str, lexer_path: &PathBuf, yacc_path: &PathBuf) -> ast::Arena<String> {
+fn parse_file<T: Copy + PartialEq>(filename: &str,
+                                   lexer_path: &PathBuf,
+                                   yacc_path: &PathBuf)
+                                   -> ast::Arena<String, T> {
     let error_to_str = |err| {
         use ast::ParseError::*;
         match err {
@@ -249,7 +252,7 @@ fn parse_file(filename: &str, lexer_path: &PathBuf, yacc_path: &PathBuf) -> ast:
             _ => format!("Error parsing {}.", filename),
         }
     };
-    ast::parse_file(filename, lexer_path, yacc_path)
+    ast::parse_file::<T>(filename, lexer_path, yacc_path)
         .map_err(error_to_str)
         .map_err(|ref msg| exit_with_message(msg))
         .unwrap()
@@ -364,8 +367,8 @@ fn main() {
     let (lexer1, parser1, lexer2, parser2) = get_parsers(&args);
 
     // Parse both input files.
-    let ast_base = parse_file(&args.arg_base_file, &lexer1, &parser1);
-    let ast_diff = parse_file(&args.arg_diff_file, &lexer2, &parser2);
+    let ast_base = parse_file::<ast::FromNodeId>(&args.arg_base_file, &lexer1, &parser1);
+    let ast_diff = parse_file::<ast::ToNodeId>(&args.arg_diff_file, &lexer2, &parser2);
 
     // Dump ASTs to STDOUT, if requested.
     if args.flag_ast {

--- a/tests/test_ast.rs
+++ b/tests/test_ast.rs
@@ -42,7 +42,7 @@ extern crate diffract;
 
 use std::path::Path;
 
-use diffract::ast::{ParseError, parse_file};
+use diffract::ast::{Arena, FromNodeId, ParseError, parse_file};
 
 fn compare_ast_dump_to_lrpar_output(is_java: bool, filepath: &str, expected: &str) {
     let lex = if is_java {
@@ -55,7 +55,7 @@ fn compare_ast_dump_to_lrpar_output(is_java: bool, filepath: &str, expected: &st
     } else {
         Path::new("grammars/calc.y")
     };
-    let arena = parse_file(filepath, lex, yacc).unwrap();
+    let arena: Arena<String, FromNodeId> = parse_file(filepath, lex, yacc).unwrap();
     let arena_pretty_printed = format!("{:?}", arena);
     // Remove `\r` from pretty printed string, as the 'expected' values all
     // use UNIX line endings.
@@ -441,7 +441,7 @@ fn test_nested_comment_java() {
 fn test_non_existant_input() {
     let lex = Path::new("grammars/calc.l");
     let yacc = Path::new("grammars/calc.y");
-    let ast_result = parse_file("nosuchfileexists.calc", lex, yacc);
+    let ast_result = parse_file::<FromNodeId>("nosuchfileexists.calc", lex, yacc);
     match ast_result {
         Err(ParseError::FileNotFound(s)) => assert_eq!(s, String::from("nosuchfileexists.calc")),
         Err(e) => panic!("Expected FileNotFound error, got: {:?}", e),
@@ -453,7 +453,7 @@ fn test_non_existant_input() {
 fn test_non_existant_lex() {
     let lex = Path::new("grammars/nosuchfileexists.l");
     let yacc = Path::new("grammars/calc.y");
-    let ast_result = parse_file("tets/one.calc", lex, yacc);
+    let ast_result = parse_file::<FromNodeId>("tets/one.calc", lex, yacc);
     match ast_result {
         Err(ParseError::FileNotFound(s)) => {
             assert_eq!(s, String::from("grammars/nosuchfileexists.l"))
@@ -467,7 +467,7 @@ fn test_non_existant_lex() {
 fn test_non_existant_grm() {
     let lex = Path::new("grammars/calc.l");
     let yacc = Path::new("grammars/nosuchfileexists.y");
-    let ast_result = parse_file("tests/one.calc", lex, yacc);
+    let ast_result = parse_file::<FromNodeId>("tests/one.calc", lex, yacc);
     match ast_result {
         Err(ParseError::FileNotFound(s)) => {
             assert_eq!(s, String::from("grammars/nosuchfileexists.y"))
@@ -481,7 +481,7 @@ fn test_non_existant_grm() {
 fn test_lexical_err() {
     let lex = Path::new("grammars/calc.l");
     let yacc = Path::new("grammars/calc.y");
-    let ast_result = parse_file("tests/calc_lexical_err.calc", lex, yacc);
+    let ast_result = parse_file::<FromNodeId>("tests/calc_lexical_err.calc", lex, yacc);
     match ast_result {
         Err(ParseError::LexicalError) => assert!(true),
         Err(e) => panic!("Expected LexicalError error, got: {:?}", e),
@@ -493,7 +493,7 @@ fn test_lexical_err() {
 fn test_syntax_err() {
     let lex = Path::new("grammars/calc.l");
     let yacc = Path::new("grammars/calc.y");
-    let ast_result = parse_file("tests/calc_syntax_err.calc", lex, yacc);
+    let ast_result = parse_file::<FromNodeId>("tests/calc_syntax_err.calc", lex, yacc);
     match ast_result {
         Err(ParseError::SyntaxError) => assert!(true),
         Err(e) => panic!("Expected SyntaxError error, got: {:?}", e),
@@ -505,7 +505,7 @@ fn test_syntax_err() {
 fn test_broken_lex() {
     let lex = Path::new("tests/grammars/broken.l");
     let yacc = Path::new("grammars/txt.y");
-    let ast_result = parse_file("tests/lorem1.txt", lex, yacc);
+    let ast_result = parse_file::<FromNodeId>("tests/lorem1.txt", lex, yacc);
     match ast_result {
         Err(ParseError::BrokenLexer) => assert!(true),
         Err(e) => panic!("Expected BrokenLexer error, got: {:?}", e),
@@ -517,7 +517,7 @@ fn test_broken_lex() {
 fn test_broken_grm() {
     let lex = Path::new("grammars/txt.l");
     let yacc = Path::new("tests/grammars/broken.y");
-    let ast_result = parse_file("tests/lorem1.txt", lex, yacc);
+    let ast_result = parse_file::<FromNodeId>("tests/lorem1.txt", lex, yacc);
     match ast_result {
         Err(ParseError::BrokenParser) => assert!(true),
         Err(e) => panic!("Expected BrokenParser error, got: {:?}", e),

--- a/tests/test_hqueue.rs
+++ b/tests/test_hqueue.rs
@@ -44,18 +44,18 @@ extern crate diffract;
 
 use std::path::Path;
 
-use diffract::ast::{Arena, NodeId, parse_file};
+use diffract::ast::{Arena, FromNodeId, NodeId, parse_file};
 use diffract::hqueue::HeightQueue;
 
 // Assert that `queue` is in sorted order and has the same size `arena`.
-fn assert_sorted<T: Clone>(queue: &HeightQueue, arena: &Arena<T>) {
+fn assert_sorted<T: Clone>(queue: &HeightQueue<FromNodeId>, arena: &Arena<T, FromNodeId>) {
     let mut expected = arena.size();
     if expected == 0 {
         assert!(queue.is_empty());
         return;
     }
     let mut clone = queue.clone();
-    let mut tallest: Vec<NodeId>;
+    let mut tallest: Vec<NodeId<FromNodeId>>;
     loop {
         tallest = clone.pop();
         println!("{:?}", tallest);


### PR DESCRIPTION
Fixes #57 

This PR:

  * Introduces separate `FromNodeId` and `ToNodeId` types for `NodeId`, to differentiate *from* and *to* ASTs in the source code. This is intended to avoid bugs where actions are applied to the "wrong" tree.
  * Implements the `From` trait for `NodeId`, `Node` and `Arena` in the `ast` module (only available when testing).
  * Updates Diffract with respect to the lrpar API.
  * Runs `rustfmt` over all affected modules.

It is probably worth reviewing by commit, since the `NodeId` commit is so large.

**NEEDS SQUASHING** 