### PR TITLE
Use standard terms for type and labels of AST nodes.

### DIFF
--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -157,11 +157,11 @@ impl Chawathe96Config {
                 if store.is_mapped_by_matcher(a, b) && !lcs.contains(&(*a, *b)) {
                     let k = self.find_pos(store, *b, from_in_order, to_in_order);
                     let mut mov = Move::new(*a, w, k);
-                    debug!("Edit script align_children: MOV {} {:?} Parent: {} {:?} Child: {}",
+                    debug!("Edit script align_children: MOV {:?} {} Parent: {:?} {} Child: {}",
+                           store.from_arena[*a].ty,
                            store.from_arena[*a].label,
-                           store.from_arena[*a].value,
+                           store.from_arena[w].ty.clone(),
                            store.from_arena[w].label.clone(),
-                           store.from_arena[w].value.clone(),
                            k);
                     script.push(mov.clone());
                     mov.apply(&mut store.from_arena)?;
@@ -292,10 +292,10 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                 // be used when the "from" and "to" ASTs have been parsed
                 // into different grammars.
                 let k = self.find_pos(store, x, &from_in_order, &to_in_order);
-                debug!("Edit script: INS {} {:?} No parent",
-                       store.to_arena[x].label,
-                       store.to_arena[x].value);
-                w = store.from_arena.new_node(store.to_arena[x].value.clone(),
+                debug!("Edit script: INS {:?} {} No parent",
+                       store.to_arena[x].ty,
+                       store.to_arena[x].label);
+                w = store.from_arena.new_node(store.to_arena[x].ty.clone(),
                                               store.to_arena[x].label.clone(),
                                               store.to_arena[x].col_no,
                                               store.to_arena[x].line_no,
@@ -310,12 +310,12 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                 let z = store.get_from(&y).unwrap();
                 // (b) if x has no partner in M': i. let k<-find_pos(x),
                 let k = self.find_pos(store, x, &from_in_order, &to_in_order);
-                debug!("Edit script: INS {} {:?} Parent: {} {:?}",
+                debug!("Edit script: INS {:?} {} Parent: {:?} {}",
+                       store.to_arena[x].ty,
                        store.to_arena[x].label,
-                       store.to_arena[x].value,
-                       store.from_arena[z].label,
-                       store.from_arena[z].value);
-                w = store.from_arena.new_node(store.to_arena[x].value.clone(),
+                       store.from_arena[z].ty,
+                       store.from_arena[z].label);
+                w = store.from_arena.new_node(store.to_arena[x].ty.clone(),
                                               store.to_arena[x].label.clone(),
                                               store.to_arena[x].col_no,
                                               store.to_arena[x].line_no,
@@ -335,14 +335,14 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                 w = store.get_from(&x).unwrap();
                 let v = store.from_arena[w].parent().unwrap();
                 // ii. if value_of(w) != value_of(x):
-                if store.from_arena[w].value != store.to_arena[x].value {
-                    debug!("Edit script: UPD {} {:?} -> {} {:?}",
+                if store.from_arena[w].ty != store.to_arena[x].ty {
+                    debug!("Edit script: UPD {:?} {} -> {:?} {}",
+                           store.from_arena[w].ty,
                            store.from_arena[w].label,
-                           store.from_arena[w].value,
-                           store.to_arena[x].label,
-                           store.to_arena[x].value);
+                           store.to_arena[x].ty,
+                           store.to_arena[x].label);
                     let mut upd = Update::new(w,
-                                              store.to_arena[x].value.clone(),
+                                              store.to_arena[x].ty.clone(),
                                               store.to_arena[x].label.clone());
                     // B. Apply UPD(w, v(x)) to T_1.
                     upd.apply(&mut store.from_arena)?;
@@ -358,11 +358,11 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                     // B. Let k<-find_pos(x).
                     let k = self.find_pos(store, x, &from_in_order, &to_in_order);
                     let mut mov = Move::new(w, z, k);
-                    debug!("Edit script: MOV {} {:?} Parent: {} {:?} Child: {}",
+                    debug!("Edit script: MOV {:?} {} Parent: {:?} {} Child: {}",
+                           store.from_arena[w].ty,
                            store.from_arena[w].label,
-                           store.from_arena[w].value,
+                           store.from_arena[z].ty,
                            store.from_arena[z].label,
-                           store.from_arena[z].value,
                            k);
                     // D. Apply MOV(w, z, k) to T_1.
                     mov.apply(&mut store.from_arena)?;
@@ -386,9 +386,9 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
             // (b) If w has no partner in M' then append DEL(w) to E and apply
             // DEL(w) to T_1.
             if !store.contains_from(&w) {
-                debug!("Edit script: DEL {} {:?}",
-                       store.from_arena[w].label,
-                       store.from_arena[w].value);
+                debug!("Edit script: DEL {:?} {}",
+                       store.from_arena[w].ty,
+                       store.from_arena[w].label);
                 let del = Delete::new(w);
                 script.push(del.clone());
                 actions.push(del);

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -268,8 +268,8 @@ impl<'a, T: PartialEq + Copy> Labeller<'a, NodeId<T>, EdgeId<T>> for Arena<Strin
 
     fn node_label(&self, id: &NodeId<T>) -> LabelText {
         let label = format!("{} {}",
-                            self[*id].label,
-                            escape_string(self[*id].value.as_str()));
+                            escape_string(self[*id].ty.as_str()),
+                            self[*id].label);
         LabelText::LabelStr(label.into())
     }
 }
@@ -321,16 +321,16 @@ impl RenderDotfile for MappingStore<String> {
             } else {
                 attrs = "";
             }
-            if self.from_arena[from_node].value.is_empty() {
+            if self.from_arena[from_node].label.is_empty() {
                 digraph.push(format!("\tFROM{}[label=\"{}\"{}];\n",
                                      id,
-                                     self.from_arena[from_node].label,
+                                     escape_string(self.from_arena[from_node].ty.as_str()),
                                      attrs));
             } else {
                 digraph.push(format!("\tFROM{}[label=\"{} {}\"{}];\n",
                                      id,
-                                     self.from_arena[from_node].label,
-                                     escape_string(self.from_arena[from_node].value.as_str()),
+                                     escape_string(self.from_arena[from_node].ty.as_str()),
+                                     escape_string(self.from_arena[from_node].label.as_str()),
                                      attrs));
             }
         }
@@ -341,16 +341,16 @@ impl RenderDotfile for MappingStore<String> {
             } else {
                 attrs = "";
             }
-            if self.to_arena[to_node].value.is_empty() {
+            if self.to_arena[to_node].label.is_empty() {
                 digraph.push(format!("\tTO{}[label=\"{}\"{}];\n",
                                      id,
-                                     self.to_arena[to_node].label,
+                                     escape_string(self.to_arena[to_node].ty.as_str()),
                                      attrs));
             } else {
                 digraph.push(format!("\tTO{}[label=\"{} {}\"{}];\n",
                                      id,
-                                     self.to_arena[to_node].label,
-                                     escape_string(self.to_arena[to_node].value.as_str()),
+                                     escape_string(self.to_arena[to_node].ty.as_str()),
+                                     escape_string(self.to_arena[to_node].label.as_str()),
                                      attrs));
             }
         }

--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -183,47 +183,47 @@ mod tests {
     use ast::FromNodeId;
     use test::Bencher;
 
-    fn create_arena() -> Arena<String, FromNodeId> {
+    fn create_arena() -> Arena<&'static str, FromNodeId> {
         let mut arena = Arena::new();
-        let root = arena.new_node(String::from("+"),
-                                  String::from("Expr"),
+        let root = arena.new_node("Expr",
+                                  String::from("+"),
                                   None,
                                   None,
                                   None,
                                   None);
-        let n1 = arena.new_node(String::from("1"),
-                                String::from("INT"),
+        let n1 = arena.new_node("INT",
+                                String::from("1"),
                                 None,
                                 None,
                                 None,
                                 None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node(String::from("*"),
-                                String::from("Expr"),
+        let n2 = arena.new_node("Expr",
+                                String::from("*"),
                                 None,
                                 None,
                                 None,
                                 None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node(String::from("3"),
-                                String::from("INT"),
+        let n3 = arena.new_node("INT",
+                                String::from("3"),
                                 None,
                                 None,
                                 None,
                                 None);
         n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node(String::from("4"),
-                                String::from("INT"),
+        let n4 = arena.new_node("INT",
+                                String::from("4"),
                                 None,
                                 None,
                                 None,
                                 None);
         n4.make_child_of(n2, &mut arena).unwrap();
-        let format1 = "Expr \"+\"
-  INT \"1\"
-  Expr \"*\"
-    INT \"3\"
-    INT \"4\"
+        let format1 = "\"Expr\" +
+  \"INT\" 1
+  \"Expr\" *
+    \"INT\" 3
+    \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
         arena
@@ -356,9 +356,9 @@ mod tests {
 
     #[bench]
     fn bench_push(bencher: &mut Bencher) {
-        let mut arena: Arena<String, FromNodeId> = Arena::new();
+        let mut arena: Arena<&str, FromNodeId> = Arena::new();
         for _ in 0..BENCH_ITER {
-            arena.new_node(String::from(""), String::from(""), None, None, None, None);
+            arena.new_node("", String::from(""), None, None, None, None);
         }
         let mut queue = HeightQueue::new();
         // Because `HeightQueues` are sets, each iteration of this

--- a/src/lib/myers_matcher.rs
+++ b/src/lib/myers_matcher.rs
@@ -101,11 +101,11 @@ Variations.";
     }
 }
 
-/// Test that two nodes have the same label and value.
+/// Test that two nodes have the same label and type.
 fn eq<T: Clone + Debug + Eq>(n1: &NodeId<FromNodeId>,
                              arena1: &Arena<T, FromNodeId>,
                              n2: &NodeId<ToNodeId>,
                              arena2: &Arena<T, ToNodeId>)
                              -> bool {
-    arena1[*n1].label == arena2[*n2].label && arena1[*n1].value == arena2[*n2].value
+    arena1[*n1].label == arena2[*n2].label && arena1[*n1].ty == arena2[*n2].ty
 }

--- a/src/lib/sequence.rs
+++ b/src/lib/sequence.rs
@@ -154,7 +154,7 @@ mod tests {
                                  n2: &NodeId<ToNodeId>,
                                  arena2: &Arena<T, ToNodeId>)
                                  -> bool {
-        arena1[*n1].label == arena2[*n2].label && arena1[*n1].value == arena2[*n2].value
+        arena1[*n1].label == arena2[*n2].label && arena1[*n1].ty == arena2[*n2].ty
     }
 
     fn assert_sequence_correct<T: Clone + Debug + Eq>(store: MappingStore<T>, expected: &[T]) {
@@ -172,8 +172,8 @@ mod tests {
                             .collect::<Vec<NodeId<ToNodeId>>>();
         let longest = lcss(&base, &store.from_arena, &diff, &store.to_arena, &eq);
         for (i, value) in longest.iter().enumerate() {
-            assert_eq!(expected[i], store.from_arena[value.0].value);
-            assert_eq!(expected[i], store.to_arena[value.1].value);
+            assert_eq!(expected[i], store.from_arena[value.0].ty);
+            assert_eq!(expected[i], store.to_arena[value.1].ty);
         }
     }
 
@@ -190,9 +190,9 @@ mod tests {
                                            None,
                                            None,
                                            None);
-            for value in base {
+            for ty in base {
                 from_id =
-                    base_arena.new_node(value.clone(), String::from("T"), None, None, None, None);
+                    base_arena.new_node(ty.clone(), String::from("T"), None, None, None, None);
                 from_id.make_child_of(root, &mut base_arena).unwrap();
 
             }
@@ -205,9 +205,9 @@ mod tests {
                                            None,
                                            None,
                                            None);
-            for value in diff {
+            for ty in diff {
                 to_id =
-                    diff_arena.new_node(value.clone(), String::from("T"), None, None, None, None);
+                    diff_arena.new_node(ty.clone(), String::from("T"), None, None, None, None);
                 to_id.make_child_of(root, &mut diff_arena).unwrap();
             }
         }

--- a/tests/test_ast.rs
+++ b/tests/test_ast.rs
@@ -68,15 +68,15 @@ fn test_empty_calc() {
     compare_ast_dump_to_lrpar_output(
         false,
         "tests/empty.calc",
-        "^~
-  ~
-    WHITESPACE \" \\n\"
-    ~
-  Expr
-    Term
-      Factor
-",
-    );
+        "\"^~\"
+  \"~\"
+    \"WHITESPACE\"  \n
+    \"~\"
+  \"Expr\"
+    \"Term\"
+      \"Factor\"
+"
+  );
 }
 
 #[test]
@@ -84,15 +84,15 @@ fn test_one_calc() {
     compare_ast_dump_to_lrpar_output(
         false,
         "tests/one.calc",
-        "^~
-  ~
-  Expr
-    Term
-      Factor
-        INT \"1\"
-        ~
-          WHITESPACE \"\\n\"
-          ~
+        "\"^~\"
+  \"~\"
+  \"Expr\"
+    \"Term\"
+      \"Factor\"
+        \"INT\" 1
+        \"~\"
+          \"WHITESPACE\" \n
+          \"~\"
 ",
     );
 }
@@ -102,22 +102,22 @@ fn test_add_calc() {
     compare_ast_dump_to_lrpar_output(
         false,
         "tests/add.calc",
-        "^~
-  ~
-  Expr
-    Term
-      Factor
-        INT \"1\"
-        ~
-    PLUS \"+\"
-    ~
-    Expr
-      Term
-        Factor
-          INT \"2\"
-          ~
-            WHITESPACE \"\\n\"
-            ~
+        "\"^~\"
+  \"~\"
+  \"Expr\"
+    \"Term\"
+      \"Factor\"
+        \"INT\" 1
+        \"~\"
+    \"PLUS\" +
+    \"~\"
+    \"Expr\"
+      \"Term\"
+        \"Factor\"
+          \"INT\" 2
+          \"~\"
+            \"WHITESPACE\" \n
+            \"~\"
 ",
     );
 }
@@ -127,263 +127,28 @@ fn test_mult_calc() {
     compare_ast_dump_to_lrpar_output(
         false,
         "tests/mult.calc",
-        "^~
-  ~
-  Expr
-    Term
-      Factor
-        INT \"3\"
-        ~
-      MULT \"*\"
-      ~
-      Term
-        Factor
-          INT \"1\"
-          ~
-    PLUS \"+\"
-    ~
-    Expr
-      Term
-        Factor
-          INT \"2\"
-          ~
-            WHITESPACE \"\\n\"
-            ~
-",
-    );
-}
-
-#[test]
-fn test_hello_java() {
-    compare_ast_dump_to_lrpar_output(
-        true,
-        "tests/Hello.java",
-        "^~
-  ~
-  goal
-    compilation_unit
-      package_declaration_opt
-      import_declarations_opt
-      type_declarations_opt
-        type_declarations
-          type_declaration
-            class_declaration
-              modifiers_opt
-                modifiers
-                  modifier
-                    PUBLIC \"public\"
-                    ~
-                      WHITESPACE \" \"
-                      ~
-              CLASS \"class\"
-              ~
-                WHITESPACE \" \"
-                ~
-              IDENTIFIER \"Hello\"
-              ~
-                WHITESPACE \" \"
-                ~
-              type_parameters_opt
-              super_opt
-              interfaces_opt
-              class_body
-                LBRACE \"{\"
-                ~
-                  WHITESPACE \"\\n    \"
-                  ~
-                class_body_declarations_opt
-                  class_body_declarations
-                    class_body_declaration
-                      class_member_declaration
-                        method_declaration
-                          method_header
-                            modifiers_opt
-                              modifiers
-                                modifiers
-                                  modifier
-                                    PUBLIC \"public\"
-                                    ~
-                                      WHITESPACE \" \"
-                                      ~
-                                modifier
-                                  STATIC \"static\"
-                                  ~
-                                    WHITESPACE \" \"
-                                    ~
-                            VOID \"void\"
-                            ~
-                              WHITESPACE \" \"
-                              ~
-                            method_declarator
-                              IDENTIFIER \"main\"
-                              ~
-                              LPAREN \"(\"
-                              ~
-                              formal_parameter_list_opt
-                                formal_parameter_list
-                                  formal_parameter
-                                    type
-                                      reference_type
-                                        array_type
-                                          name
-                                            simple_name
-                                              IDENTIFIER \"String\"
-                                              ~
-                                          dims
-                                            LBRACK \"[\"
-                                            ~
-                                            RBRACK \"]\"
-                                            ~
-                                              WHITESPACE \" \"
-                                              ~
-                                    variable_declarator_id
-                                      IDENTIFIER \"args\"
-                                      ~
-                              RPAREN \")\"
-                              ~
-                                WHITESPACE \" \"
-                                ~
-                            throws_opt
-                          method_body
-                            block
-                              LBRACE \"{\"
-                              ~
-                                WHITESPACE \"\\n        \"
-                                ~
-                              block_statements_opt
-                                block_statements
-                                  block_statement
-                                    statement
-                                      statement_without_trailing_substatement
-                                        expression_statement
-                                          statement_expression
-                                            method_invocation
-                                              qualified_name
-                                                name
-                                                  qualified_name
-                                                    name
-                                                      simple_name
-                                                        IDENTIFIER \"System\"
-                                                        ~
-                                                    DOT \".\"
-                                                    ~
-                                                    IDENTIFIER \"out\"
-                                                    ~
-                                                DOT \".\"
-                                                ~
-                                                IDENTIFIER \"println\"
-                                                ~
-                                              LPAREN \"(\"
-                                              ~
-                                              argument_list_opt
-                                                argument_list
-                                                  expression
-                                                    assignment_expression
-                                                      conditional_expression
-                                                        conditional_or_expression
-                                                          conditional_and_expression
-                                                            inclusive_or_expression
-                                                              exclusive_or_expression
-                                                                and_expression
-                                                                  equality_expression
-                                                                    instanceof_expression
-                                                                      relational_expression
-                                                                        shift_expression
-                                                                          additive_expression
-                                                                            multiplicative_expression
-                                                                              unary_expression
-                                                                                unary_expression_not_plus_minus
-                                                                                  postfix_expression
-                                                                                    primary
-                                                                                      primary_no_new_array
-                                                                                        literal
-                                                                                          STRING_LITERAL \"\\\"Hello, world!\\\"\"
-                                                                                          ~
-                                              RPAREN \")\"
-                                              ~
-                                          SEMICOLON \";\"
-                                          ~
-                                            WHITESPACE \"\\n    \"
-                                            ~
-                              RBRACE \"}\"
-                              ~
-                                WHITESPACE \"\\n\"
-                                ~
-                RBRACE \"}\"
-                ~
-                  WHITESPACE \"\\n\"
-                  ~
-",
-    );
-}
-
-#[test]
-fn test_comment_java() {
-    compare_ast_dump_to_lrpar_output(
-        true,
-        "tests/Comment.java",
-        "^~
-  ~
-    COMMENT \"/* Multiline 1 */\"
-    ~
-      WHITESPACE \"\\n\"
-      ~
-  goal
-    compilation_unit
-      package_declaration_opt
-      import_declarations_opt
-      type_declarations_opt
-        type_declarations
-          type_declaration
-            class_declaration
-              modifiers_opt
-                modifiers
-                  modifier
-                    PUBLIC \"public\"
-                    ~
-                      WHITESPACE \" \"
-                      ~
-                        COMMENT \"/* Multiline 2 */\"
-                        ~
-                          WHITESPACE \" \"
-                          ~
-              CLASS \"class\"
-              ~
-                WHITESPACE \" \"
-                ~
-                  COMMENT \"/* Multiline 3 */\"
-                  ~
-                    WHITESPACE \" \"
-                    ~
-              IDENTIFIER \"Comment\"
-              ~
-                WHITESPACE \" \"
-                ~
-                  COMMENT \"/* Multiline 4 */\"
-                  ~
-                    WHITESPACE \" \"
-                    ~
-              type_parameters_opt
-              super_opt
-              interfaces_opt
-              class_body
-                LBRACE \"{\"
-                ~
-                  WHITESPACE \"\\n    \"
-                  ~
-                    COMMENT \"// Single line comment.\"
-                    ~
-                      WHITESPACE \"\\n\"
-                      ~
-                class_body_declarations_opt
-                RBRACE \"}\"
-                ~
-                  WHITESPACE \" \"
-                  ~
-                    COMMENT \"/* Multiline 5\\n   *\\n   *\\n   *\\n   */\"
-                    ~
-                      WHITESPACE \"\\n\"
-                      ~
+        "\"^~\"
+  \"~\"
+  \"Expr\"
+    \"Term\"
+      \"Factor\"
+        \"INT\" 3
+        \"~\"
+      \"MULT\" *
+      \"~\"
+      \"Term\"
+        \"Factor\"
+          \"INT\" 1
+          \"~\"
+    \"PLUS\" +
+    \"~\"
+    \"Expr\"
+      \"Term\"
+        \"Factor\"
+          \"INT\" 2
+          \"~\"
+            \"WHITESPACE\" \n
+            \"~\"
 ",
     );
 }
@@ -393,46 +158,45 @@ fn test_nested_comment_java() {
     compare_ast_dump_to_lrpar_output(
         true,
         "tests/NestedComment.java",
-        "^~
-  ~
-    COMMENT \"/*\\n * // Single line comment nested in multi-line comment.\\n */\"
-    ~
-      WHITESPACE \"\\n\"
-      ~
-  goal
-    compilation_unit
-      package_declaration_opt
-      import_declarations_opt
-      type_declarations_opt
-        type_declarations
-          type_declaration
-            class_declaration
-              modifiers_opt
-                modifiers
-                  modifier
-                    PUBLIC \"public\"
-                    ~
-                      WHITESPACE \" \"
-                      ~
-              CLASS \"class\"
-              ~
-                WHITESPACE \" \"
-                ~
-              IDENTIFIER \"NestedComment\"
-              ~
-                WHITESPACE \" \"
-                ~
-              type_parameters_opt
-              super_opt
-              interfaces_opt
-              class_body
-                LBRACE \"{\"
-                ~
-                class_body_declarations_opt
-                RBRACE \"}\"
-                ~
-                  WHITESPACE \"\\n\"
-                  ~
+        "\"^~\"
+  \"~\"
+    \"COMMENT\" /*
+ * // Single line comment nested in multi-line comment.
+ */
+    \"~\"
+      \"WHITESPACE\" \n
+      \"~\"
+  \"goal\"
+    \"compilation_unit\"
+      \"package_declaration_opt\"
+      \"import_declarations_opt\"
+      \"type_declarations_opt\"
+        \"type_declarations\"
+          \"type_declaration\"
+            \"class_declaration\"
+              \"modifiers_opt\"
+                \"modifiers\"
+                  \"modifier\"
+                    \"PUBLIC\" public
+                    \"~\"
+                      \"WHITESPACE\"  \n                      \"~\"
+              \"CLASS\" class
+              \"~\"
+                \"WHITESPACE\"  \n                \"~\"
+              \"IDENTIFIER\" NestedComment
+              \"~\"
+                \"WHITESPACE\"  \n                \"~\"
+              \"type_parameters_opt\"
+              \"super_opt\"
+              \"interfaces_opt\"
+              \"class_body\"
+                \"LBRACE\" {
+                \"~\"
+                \"class_body_declarations_opt\"
+                \"RBRACE\" }
+                \"~\"
+                  \"WHITESPACE\" \n
+                  \"~\"
 ",
     );
 }


### PR DESCRIPTION
**NEEDS SQUASHING**

Fixes #49 

This PR introduces a small API change to rename the `value` of a node as `type` (node `label`s stay the same). 

This has been the cause of much confusion in the code base, and you will notice that there are places where very similar functions have swapped the order types and labels, or where one has been used where the other was expected, and so on.

To avoid further confusion, the unit tests (but not necessarily integration tests) now prefer `&str` to `String` for the type of node types. This avoids confusing between node types and labels and allows the type checker to report any future mistakes.

I've also removed the `hello_java` test from `tests/test_ast.rs` because its expected output was too long to sensibly maintain, and the test did not add anything to the Java nested comment test in the same file.  

GraphViz output still looks OK: [map.pdf](https://github.com/softdevteam/diffract/files/1549724/map.pdf)
