### PR TITLE
Update rustfmt config.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,1 @@
-chain_indent = "Visual"
+indent_style = "Visual"


### PR DESCRIPTION
`chain_indent` no longer exists in the rustfmt TOML configuration, and using it with the latest rustfmt gives an error message. This PR brings the Diffract repo up to date with nightly.

See: https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md for configuration details.