### PR TITLE
Add store ref cells

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
+max_width = 120
 indent_style = "Visual"

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -119,7 +119,6 @@ pub struct Update<T: Clone> {
     label: String,
 }
 
-
 /// Copy a subtree from one place to another with an AST.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Copy {
@@ -127,7 +126,6 @@ pub struct Copy {
     parent: NodeId<FromNodeId>,
     pos: u16,
 }
-
 
 /// Glue a subtree from one place to another with an AST.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -146,54 +144,44 @@ impl Delete {
 impl Insert {
     /// Create a new `Insert` object.
     pub fn new(node: NodeId<FromNodeId>, parent: Option<NodeId<FromNodeId>>, nth: u16) -> Insert {
-        Insert {
-            node: node,
-            new_parent: parent,
-            nth_child: nth,
-        }
+        Insert { node: node,
+                 new_parent: parent,
+                 nth_child: nth, }
     }
 }
 
 impl Move {
     /// Create a new `Move` object.
     pub fn new(from: NodeId<FromNodeId>, parent: NodeId<FromNodeId>, position: u16) -> Move {
-        Move {
-            from_node: from,
-            parent: parent,
-            pos: position,
-        }
+        Move { from_node: from,
+               parent: parent,
+               pos: position, }
     }
 }
 
 impl<T: Clone + Debug> Update<T> {
     /// Create a new `Update` object.
     pub fn new(node: NodeId<FromNodeId>, ty: T, label: String) -> Update<T> {
-        Update {
-            node: node,
-            ty: ty,
-            label: label,
-        }
+        Update { node: node,
+                 ty: ty,
+                 label: label, }
     }
 }
 
 impl Copy {
     /// Create a new `Copy` object.
     pub fn new(from: NodeId<FromNodeId>, parent: NodeId<FromNodeId>, position: u16) -> Copy {
-        Copy {
-            from_node: from,
-            parent: parent,
-            pos: position,
-        }
+        Copy { from_node: from,
+               parent: parent,
+               pos: position, }
     }
 }
 
 impl Glue {
     /// Create a new `Glue` object.
     pub fn new(from: NodeId<FromNodeId>, parent: NodeId<FromNodeId>) -> Glue {
-        Glue {
-            from_node: from,
-            node: parent,
-        }
+        Glue { from_node: from,
+               node: parent, }
     }
 }
 
@@ -265,8 +253,7 @@ impl RenderJson for Copy {
         json.push(" ".repeat(indent) + "}");
         json.join("\n")
     }
-}   
-
+}
 
 impl RenderJson for Glue {
     fn render_json(&self, indent: usize) -> String {
@@ -279,11 +266,11 @@ impl RenderJson for Glue {
         json.push(" ".repeat(indent) + "}");
         json.join("\n")
     }
-}   
+}
 
 impl<T: Clone + Debug + Eq> Patchify<T> for Delete {
     fn patchify(&self, store: &MappingStore<T>, from: &mut Vec<Patch>, _: &mut Vec<Patch>) {
-        let node = &store.from_arena[self.node];
+        let node = &store.from_arena.borrow()[self.node];
         if node.char_no.is_some() {
             from.push(Patch::new(ActionType::DELETE,
                                  node.char_no.unwrap(),
@@ -294,7 +281,7 @@ impl<T: Clone + Debug + Eq> Patchify<T> for Delete {
 
 impl<T: Clone + Debug + Eq> Patchify<T> for Insert {
     fn patchify(&self, store: &MappingStore<T>, _: &mut Vec<Patch>, to: &mut Vec<Patch>) {
-        let node = &store.from_arena[self.node];
+        let node = &store.from_arena.borrow()[self.node];
         if node.char_no.is_some() {
             to.push(Patch::new(ActionType::INSERT,
                                node.char_no.unwrap(),
@@ -305,7 +292,7 @@ impl<T: Clone + Debug + Eq> Patchify<T> for Insert {
 
 impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Move {
     fn patchify(&self, store: &MappingStore<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>) {
-        let f_node = &store.from_arena[self.from_node];
+        let f_node = &store.from_arena.borrow()[self.from_node];
         if f_node.char_no.is_some() {
             from.push(Patch::new(ActionType::MOVE,
                                  f_node.char_no.unwrap(),
@@ -322,7 +309,7 @@ impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Move {
 
 impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Update<T> {
     fn patchify(&self, store: &MappingStore<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>) {
-        let f_node = &store.from_arena[self.node];
+        let f_node = &store.from_arena.borrow()[self.node];
         if f_node.char_no.is_some() {
             from.push(Patch::new(ActionType::UPDATE,
                                  f_node.char_no.unwrap(),
@@ -337,9 +324,9 @@ impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Update<T> {
     }
 }
 
-impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Copy{
+impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Copy {
     fn patchify(&self, store: &MappingStore<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>) {
-        let f_node = &store.from_arena[self.from_node];
+        let f_node = &store.from_arena.borrow()[self.from_node];
         if f_node.char_no.is_some() {
             from.push(Patch::new(ActionType::COPY,
                                  f_node.char_no.unwrap(),
@@ -354,9 +341,9 @@ impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Copy{
     }
 }
 
-impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Glue{
+impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Glue {
     fn patchify(&self, store: &MappingStore<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>) {
-        let f_node = &store.from_arena[self.from_node];
+        let f_node = &store.from_arena.borrow()[self.from_node];
         if f_node.char_no.is_some() {
             from.push(Patch::new(ActionType::GLUE,
                                  f_node.char_no.unwrap(),
@@ -391,8 +378,7 @@ impl<T: Clone + Debug + Eq> ApplyAction<T> for Insert {
 
 impl<T: Clone + Debug + Eq + 'static> ApplyAction<T> for Move {
     fn apply(&mut self, arena: &mut Arena<T, FromNodeId>) -> ArenaResult {
-        self.from_node
-            .make_nth_child_of(self.parent, self.pos, arena)
+        self.from_node.make_nth_child_of(self.parent, self.pos, arena)
     }
 }
 
@@ -406,7 +392,7 @@ impl<T: Clone + Debug + Eq + 'static> ApplyAction<T> for Update<T> {
         Ok(())
     }
 }
- 
+
 impl<T: Clone + Debug + Eq + 'static> ApplyAction<T> for Copy {
     fn apply(&mut self, arena: &mut Arena<T, FromNodeId>) -> ArenaResult {
         if !arena.contains(self.from_node) {
@@ -489,39 +475,14 @@ mod test {
 
     fn create_arena() -> Arena<&'static str, FromNodeId> {
         let mut arena = Arena::new();
-        let root = arena.new_node("Expr",
-                                  String::from("+"),
-                                  None,
-                                  None,
-                                  None,
-                                  None);
-        let n1 = arena.new_node("INT",
-                                String::from("1"),
-                                None,
-                                None,
-                                None,
-                                None);
+        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
+        let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("Expr",
-                                String::from("*"),
-                                None,
-                                None,
-                                None,
-                                None);
+        let n2 = arena.new_node("Expr", String::from("*"), None, None, None, None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node("INT",
-                                String::from("3"),
-                                None,
-                                None,
-                                None,
-                                None);
+        let n3 = arena.new_node("INT", String::from("3"), None, None, None, None);
         n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node("INT",
-                                String::from("4"),
-                                None,
-                                None,
-                                None,
-                                None);
+        let n4 = arena.new_node("INT", String::from("4"), None, None, None, None);
         n4.make_child_of(n2, &mut arena).unwrap();
         arena
     }
@@ -565,12 +526,7 @@ mod test {
     #[test]
     fn apply_insert() {
         let mut arena = create_arena();
-        let n5 = arena.new_node("INT",
-                                String::from("100"),
-                                None,
-                                None,
-                                None,
-                                None);
+        let n5 = arena.new_node("INT", String::from("100"), None, None, None, None);
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -593,12 +549,7 @@ mod test {
     #[test]
     fn apply_insert_new_root() {
         let mut arena = create_arena();
-        let n5 = arena.new_node("Expr",
-                                String::from("-"),
-                                None,
-                                None,
-                                None,
-                                None);
+        let n5 = arena.new_node("Expr", String::from("-"), None, None, None, None);
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -670,18 +621,8 @@ mod test {
     \"INT\" 3
     \"INT\" 4
 ";
-        let n5 = arena.new_node("INT",
-                                String::from("100"),
-                                None,
-                                None,
-                                None,
-                                None);
-        let n6 = arena.new_node("INT",
-                                String::from("99"),
-                                None,
-                                None,
-                                None,
-                                None);
+        let n5 = arena.new_node("INT", String::from("100"), None, None, None, None);
+        let n6 = arena.new_node("INT", String::from("99"), None, None, None, None);
         assert_eq!(format1, format!("{:?}", arena));
         // Create action list.
         let mut actions: EditScript<&str> = EditScript::new();
@@ -690,7 +631,7 @@ mod test {
         let ins1 = Insert::new(n5, Some(NodeId::new(2)), 0);
         let ins2 = Insert::new(n6, Some(NodeId::new(2)), 1);
         let mov = Move::new(NodeId::new(6), NodeId::new(2), 0); // Swap "INT 100" and "INT 99".
-        // Change "+"" to "*".
+                                                                // Change "+"" to "*".
         let upd = Update::new(NodeId::new(0), "Expr", String::from("*"));
         actions.push(del1);
         actions.push(del2);
@@ -719,26 +660,17 @@ mod test {
     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
-        let n5 = arena.new_node("INT",
-                                String::from("2"),
-                                None,
-                                None,
-                                None,
-                                None);
+        let n5 = arena.new_node("INT", String::from("2"), None, None, None, None);
         // Create action list.
         let mut actions: EditScript<&str> = EditScript::new();
-        let del = Delete { node: NodeId::new(4) }; // Remove "4".
-        let ins = Insert {
-            node: n5,
-            new_parent: Some(NodeId::new(2)),
-            nth_child: 0,
-        };
-        let upd = Update {
-            // Change "+" to "*".
-            node: NodeId::new(0),
-            ty: "Expr",
-            label: String::from("*"),
-        };
+        let del = Delete { node: NodeId::new(4), }; // Remove "4".
+        let ins = Insert { node: n5,
+                           new_parent: Some(NodeId::new(2)),
+                           nth_child: 0, };
+        let upd = Update { // Change "+" to "*".
+                           node: NodeId::new(0),
+                           ty: "Expr",
+                           label: String::from("*"), };
         actions.push(del);
         actions.push(ins);
         actions.push(upd);
@@ -761,7 +693,7 @@ mod test {
         let ins1 = Insert::new(NodeId::new(5), Some(NodeId::new(2)), 0);
         let ins2 = Insert::new(NodeId::new(6), Some(NodeId::new(2)), 1);
         let mov = Move::new(NodeId::new(6), NodeId::new(2), 0); // Swap "INT 100" and "INT 99".
-        // Change "+"" to "*".
+                                                                // Change "+"" to "*".
         let upd = Update::new(NodeId::new(0), "Expr", String::from("*"));
         actions.push(del1);
         actions.push(del2);

--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -269,6 +269,7 @@ impl Chawathe96Config {
 impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Config {
     /// This function implements the optimal algorithm of Chawathe et al. (1996).
     /// Variable names as in Figures 8 and 9 of the paper.
+    /// Will panic if either `Arena` in `store` is empty (and has no root node).
     fn generate_script(&self, store: &mut MappingStore<T>) -> EditScriptResult<T> {
         // 1. E <- e, M' <- M.
         let mut script: EditScript<T> = EditScript::new();
@@ -277,11 +278,8 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
         // Combined update, insert, align and move phases.
         // 2. Visit the nodes of T_2 in breadth-first order.
         let tmp_to_arena = store.to_arena.clone();
-        let root_to = tmp_to_arena.root()
-                                  .unwrap_or_else(|| NodeId::<ToNodeId>::new(0));
-        let root_from = store.from_arena
-                             .root()
-                             .unwrap_or_else(|| NodeId::<FromNodeId>::new(0));
+        let root_to = tmp_to_arena.root().unwrap();
+        let root_from = store.from_arena.root().unwrap();
         // (a) Let x be the current node in the breadth-first search of T_2
         // and let y be the parent of x. Let z be the partner of y in M'.
         for x in root_to.breadth_first_traversal(&tmp_to_arena) {

--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -45,14 +45,13 @@ use action::{ApplyAction, Delete, EditScript, Insert, Move, Update};
 use ast::{ArenaError, FromNodeId, NodeId, ToNodeId};
 use matchers::{EditScriptResult, MappingStore, MappingType};
 
-
 /// Given a matching between two ASTs, generate a complete edit script.
 ///
 /// This trait should usually be implemented on configuration objects that
 /// define thresholds and weights for a given algorithm.
 pub trait EditScriptGenerator<T: Clone + Debug + Eq + 'static> {
     /// Given a matching between two ASTs, generate a complete edit script.
-    fn generate_script(&self, store: &mut MappingStore<T>) -> EditScriptResult<T>;
+    fn generate_script(&self, store: &MappingStore<T>) -> EditScriptResult<T>;
 }
 
 /// The Chawathe et al. (1996) algorithm does not require any configuration.
@@ -71,10 +70,9 @@ impl Chawathe98Config {
     }
 }
 
-
 impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe98Config {
     /// This function should generate the edit script for GLUE and COPY
-    fn generate_script(&self, _store: &mut MappingStore<T>) -> EditScriptResult<T> {
+    fn generate_script(&self, _store: &MappingStore<T>) -> EditScriptResult<T> {
         Ok(EditScript::new())
     }
 }
@@ -95,25 +93,24 @@ impl Chawathe96Config {
         Default::default()
     }
 
-    fn align_children<T: Clone + Debug + Eq + 'static>(
-        &self,
-        store: &mut MappingStore<T>,
-        w: NodeId<FromNodeId>,
-        x: NodeId<ToNodeId>,
-        script: &mut EditScript<T>,
-        from_in_order: &mut HashSet<NodeId<FromNodeId>>,
-        to_in_order: &mut HashSet<NodeId<ToNodeId>>,
-) -> Result<(), ArenaError>{
+    fn align_children<T: Clone + Debug + Eq + 'static>(&self,
+                                                       store: &MappingStore<T>,
+                                                       w: NodeId<FromNodeId>,
+                                                       x: NodeId<ToNodeId>,
+                                                       script: &mut EditScript<T>,
+                                                       from_in_order: &mut HashSet<NodeId<FromNodeId>>,
+                                                       to_in_order: &mut HashSet<NodeId<ToNodeId>>)
+                                                       -> Result<(), ArenaError> {
         // Variable key:
         // a, w in store.from_arena (T_1 in paper).
         // b, x in store.to_arena (T_2 in paper).
         debug!("align_children({}, {})", w, x);
-        if w.is_leaf(&store.from_arena) && x.is_leaf(&store.to_arena) {
+        if w.is_leaf(&store.from_arena.borrow()) && x.is_leaf(&store.to_arena) {
             debug!("{} and {} both leaf nodes.", w, x);
             return Ok(());
         }
         // 1. Mark all children of w and all children of x "out of order".
-        for child in w.children(&store.from_arena) {
+        for child in w.children(&store.from_arena.borrow()) {
             from_in_order.remove(&child);
         }
         for child in x.children(&store.to_arena) {
@@ -123,7 +120,7 @@ impl Chawathe96Config {
         // children of x and let s2 be the sequence of children of x whose
         // partners are children of w.
         let mut s1: Vec<NodeId<FromNodeId>> = vec![];
-        for child in w.children(&store.from_arena) {
+        for child in w.children(&store.from_arena.borrow()) {
             if store.contains_from(&child) {
                 let mapped = store.get_to(&child).unwrap();
                 if x.children(&store.to_arena).any(|n| n == mapped) {
@@ -135,7 +132,7 @@ impl Chawathe96Config {
         for child in x.children(&store.to_arena) {
             if store.contains_to(&child) {
                 let mapped = store.get_from(&child).unwrap();
-                if w.children(&store.from_arena).any(|n| n == mapped) {
+                if w.children(&store.from_arena.borrow()).any(|n| n == mapped) {
                     s2.push(child);
                 }
             }
@@ -158,13 +155,13 @@ impl Chawathe96Config {
                     let k = self.find_pos(store, *b, from_in_order, to_in_order);
                     let mut mov = Move::new(*a, w, k);
                     debug!("Edit script align_children: MOV {:?} {} Parent: {:?} {} Child: {}",
-                           store.from_arena[*a].ty,
-                           store.from_arena[*a].label,
-                           store.from_arena[w].ty.clone(),
-                           store.from_arena[w].label.clone(),
+                           store.from_arena.borrow()[*a].ty,
+                           store.from_arena.borrow()[*a].label,
+                           store.from_arena.borrow()[w].ty.clone(),
+                           store.from_arena.borrow()[w].label.clone(),
                            k);
                     script.push(mov.clone());
-                    mov.apply(&mut store.from_arena)?;
+                    mov.apply(&mut store.from_arena.borrow_mut())?;
                     from_in_order.insert(*a);
                     to_in_order.insert(*b);
                 }
@@ -185,8 +182,7 @@ impl Chawathe96Config {
         let y = store.to_arena[x].parent().unwrap();
         // 2. If x is the leftmost child of y that is marked "in order" return
         // 0 (the paper says 1 but we count child nodes from 0).
-        let siblings = y.children(&store.to_arena)
-                        .collect::<Vec<NodeId<ToNodeId>>>();
+        let siblings = y.children(&store.to_arena).collect::<Vec<NodeId<ToNodeId>>>();
         for child in &siblings {
             if to_in_order.contains(child) {
                 if x == *child {
@@ -200,8 +196,7 @@ impl Chawathe96Config {
         let x_pos = x.get_child_position(&store.to_arena).unwrap();
         // 3. Find v in T_2, where v is the rightmost sibling of x that is to
         // the left of x and is marked "in order".
-        let v = x.children(&store.to_arena)
-                 .take(x_pos)
+        let v = x.children(&store.to_arena).take(x_pos)
                  .filter(|c| to_in_order.contains(c))
                  .last();
         if v.is_none() {
@@ -214,10 +209,9 @@ impl Chawathe96Config {
         let u = u_opt.unwrap();
         // 5. Suppose u is the i'th child of its parent that is marked
         // "in order". Return i + 1.
-        let u_p = store.from_arena[u].parent().unwrap();
-        let u_pos = u.get_child_position(&store.from_arena).unwrap();
-        let ret = u_p.children(&store.from_arena)
-                     .take(u_pos)
+        let u_p = store.from_arena.borrow()[u].parent().unwrap();
+        let u_pos = u.get_child_position(&store.from_arena.borrow()).unwrap();
+        let ret = u_p.children(&store.from_arena.borrow()).take(u_pos)
                      .filter(|c| from_in_order.contains(c))
                      .count() as u16 + 1;
         debug!("find_pos({}) <- {}", x, ret);
@@ -270,38 +264,38 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
     /// This function implements the optimal algorithm of Chawathe et al. (1996).
     /// Variable names as in Figures 8 and 9 of the paper.
     /// Will panic if either `Arena` in `store` is empty (and has no root node).
-    fn generate_script(&self, store: &mut MappingStore<T>) -> EditScriptResult<T> {
+    fn generate_script(&self, store: &MappingStore<T>) -> EditScriptResult<T> {
         // 1. E <- e, M' <- M.
         let mut script: EditScript<T> = EditScript::new();
         let mut from_in_order: HashSet<NodeId<FromNodeId>> = HashSet::new();
         let mut to_in_order: HashSet<NodeId<ToNodeId>> = HashSet::new();
         // Combined update, insert, align and move phases.
         // 2. Visit the nodes of T_2 in breadth-first order.
-        let tmp_to_arena = store.to_arena.clone();
-        let root_to = tmp_to_arena.root().unwrap();
-        let root_from = store.from_arena.root().unwrap();
+        let root_to = store.to_arena.root().unwrap();
+        let root_from = store.from_arena.borrow().root().unwrap();
         // (a) Let x be the current node in the breadth-first search of T_2
         // and let y be the parent of x. Let z be the partner of y in M'.
-        for x in root_to.breadth_first_traversal(&tmp_to_arena) {
+        for x in root_to.breadth_first_traversal(&store.to_arena) {
             let mut w = root_from; // Overwritten later.
-            // Insertion phase.
+                                   // Insertion phase.
             if !store.contains_to(&x) && x.is_root(&store.to_arena) {
                 // Handle root nodes separately. This branch is most likely to
                 // be used when the "from" and "to" ASTs have been parsed
                 // into different grammars.
                 let k = self.find_pos(store, x, &from_in_order, &to_in_order);
                 debug!("Edit script: INS {:?} {} No parent",
-                       store.to_arena[x].ty,
-                       store.to_arena[x].label);
-                w = store.from_arena.new_node(store.to_arena[x].ty.clone(),
-                                              store.to_arena[x].label.clone(),
-                                              store.to_arena[x].col_no,
-                                              store.to_arena[x].line_no,
-                                              store.to_arena[x].char_no,
-                                              store.to_arena[x].token_len);
+                       store.to_arena[x].ty, store.to_arena[x].label);
+                w = store.from_arena
+                         .borrow_mut()
+                         .new_node(store.to_arena[x].ty.clone(),
+                                   store.to_arena[x].label.clone(),
+                                   store.to_arena[x].col_no,
+                                   store.to_arena[x].line_no,
+                                   store.to_arena[x].char_no,
+                                   store.to_arena[x].token_len);
                 store.push(w, x, &MappingType::EDIT);
                 let mut ins = Insert::new(w, None, k);
-                ins.apply(&mut store.from_arena)?;
+                ins.apply(&mut store.from_arena.borrow_mut())?;
                 script.push(ins);
             } else if !store.contains_to(&x) {
                 let y = store.to_arena[x].parent().unwrap();
@@ -311,19 +305,21 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                 debug!("Edit script: INS {:?} {} Parent: {:?} {}",
                        store.to_arena[x].ty,
                        store.to_arena[x].label,
-                       store.from_arena[z].ty,
-                       store.from_arena[z].label);
-                w = store.from_arena.new_node(store.to_arena[x].ty.clone(),
-                                              store.to_arena[x].label.clone(),
-                                              store.to_arena[x].col_no,
-                                              store.to_arena[x].line_no,
-                                              store.to_arena[x].char_no,
-                                              store.to_arena[x].token_len);
+                       store.from_arena.borrow()[z].ty,
+                       store.from_arena.borrow()[z].label);
+                w = store.from_arena
+                         .borrow_mut()
+                         .new_node(store.to_arena[x].ty.clone(),
+                                   store.to_arena[x].label.clone(),
+                                   store.to_arena[x].col_no,
+                                   store.to_arena[x].line_no,
+                                   store.to_arena[x].char_no,
+                                   store.to_arena[x].token_len);
                 // iii. Add (w, x) to M' and apply INS((w, a, v(x)), z, k) to T_1.
                 store.push(w, x, &MappingType::EDIT);
                 // ii. Append INS((w, a, v(x)), z, k) to E for new identifier w
                 let mut ins = Insert::new(w, Some(z), k);
-                ins.apply(&mut store.from_arena)?;
+                ins.apply(&mut store.from_arena.borrow_mut())?;
                 script.push(ins);
             } else if !x.is_root(&store.to_arena) {
                 // Insertion and update phases.
@@ -331,19 +327,19 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                 // i. Let w be the partner of x in M' and let v be the parent
                 // of w in T_1.
                 w = store.get_from(&x).unwrap();
-                let v = store.from_arena[w].parent().unwrap();
+                let v = store.from_arena.borrow()[w].parent().unwrap();
                 // ii. if value_of(w) != value_of(x):
-                if store.from_arena[w].ty != store.to_arena[x].ty {
+                if store.from_arena.borrow()[w].ty != store.to_arena[x].ty {
                     debug!("Edit script: UPD {:?} {} -> {:?} {}",
-                           store.from_arena[w].ty,
-                           store.from_arena[w].label,
+                           store.from_arena.borrow()[w].ty,
+                           store.from_arena.borrow()[w].label,
                            store.to_arena[x].ty,
                            store.to_arena[x].label);
                     let mut upd = Update::new(w,
                                               store.to_arena[x].ty.clone(),
                                               store.to_arena[x].label.clone());
                     // B. Apply UPD(w, v(x)) to T_1.
-                    upd.apply(&mut store.from_arena)?;
+                    upd.apply(&mut store.from_arena.borrow_mut())?;
                     // A. Append UPD(w, v(x)) to E.
                     script.push(upd.clone());
                 }
@@ -357,42 +353,42 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                     let k = self.find_pos(store, x, &from_in_order, &to_in_order);
                     let mut mov = Move::new(w, z, k);
                     debug!("Edit script: MOV {:?} {} Parent: {:?} {} Child: {}",
-                           store.from_arena[w].ty,
-                           store.from_arena[w].label,
-                           store.from_arena[z].ty,
-                           store.from_arena[z].label,
+                           store.from_arena.borrow()[w].ty,
+                           store.from_arena.borrow()[w].label,
+                           store.from_arena.borrow()[z].ty,
+                           store.from_arena.borrow()[z].label,
                            k);
                     // D. Apply MOV(w, z, k) to T_1.
-                    mov.apply(&mut store.from_arena)?;
+                    mov.apply(&mut store.from_arena.borrow_mut())?;
                     // C. Append MOV(w, z, k) to E.
                     script.push(mov);
                 }
             }
             // (d) align_children(w, x).
             self.align_children(store,
-                                w,
-                                x,
-                                &mut script,
-                                &mut from_in_order,
-                                &mut to_in_order)?;
+                                 w,
+                                 x,
+                                 &mut script,
+                                 &mut from_in_order,
+                                 &mut to_in_order)?;
         }
         // Delete phase.
         // 3. Perform a post-order traversal of T_1.
         let mut actions = EditScript::new();
         // (a) Let w be the current node in the post-order traversal of T_1.
-        for w in root_from.post_order_traversal(&store.from_arena) {
+        for w in root_from.post_order_traversal(&store.from_arena.borrow()) {
             // (b) If w has no partner in M' then append DEL(w) to E and apply
             // DEL(w) to T_1.
             if !store.contains_from(&w) {
                 debug!("Edit script: DEL {:?} {}",
-                       store.from_arena[w].ty,
-                       store.from_arena[w].label);
+                       store.from_arena.borrow()[w].ty,
+                       store.from_arena.borrow()[w].label);
                 let del = Delete::new(w);
                 script.push(del.clone());
                 actions.push(del);
             }
         }
-        actions.apply(&mut store.from_arena)?;
+        actions.apply(&mut store.from_arena.borrow_mut())?;
         Ok(script)
     }
 }

--- a/src/lib/gt_matcher.rs
+++ b/src/lib/gt_matcher.rs
@@ -57,11 +57,9 @@ pub struct GumTreeConfig {
 
 impl Default for GumTreeConfig {
     fn default() -> GumTreeConfig {
-        GumTreeConfig {
-            max_size: 100,
-            min_dice: 0.3,
-            min_height: 2,
-        }
+        GumTreeConfig { max_size: 100,
+                        min_dice: 0.3,
+                        min_height: 2, }
     }
 }
 
@@ -89,8 +87,8 @@ Code Differencing.";
 
     /// Match locations in distinct ASTs.
     fn match_trees(&self, base: Arena<T, FromNodeId>, diff: Arena<T, ToNodeId>) -> MappingStore<T> {
-        let mut store = MappingStore::new(base, diff);
-        if store.from_arena.size() == 0 || store.to_arena.size() == 0 {
+        let store = MappingStore::new(base, diff);
+        if store.from_arena.borrow().size() == 0 || store.to_arena.size() == 0 {
             return store;
         }
         store.push(NodeId::<FromNodeId>::new(0),

--- a/src/lib/myers_matcher.rs
+++ b/src/lib/myers_matcher.rs
@@ -74,14 +74,15 @@ Variations.";
 
     /// Match locations in distinct ASTs.
     fn match_trees(&self, base: Arena<T, FromNodeId>, diff: Arena<T, ToNodeId>) -> MappingStore<T> {
-        let mut store = MappingStore::new(base, diff);
-        if store.from_arena.is_empty() || store.to_arena.is_empty() {
+        let store = MappingStore::new(base, diff);
+        if store.from_arena.borrow().is_empty() || store.to_arena.is_empty() {
             return store;
         }
         let base_pre = store.from_arena
+                            .borrow()
                             .root()
                             .unwrap()
-                            .pre_order_traversal(&store.from_arena)
+                            .pre_order_traversal(&store.from_arena.borrow())
                             .collect::<Vec<NodeId<FromNodeId>>>();
         let diff_pre = store.to_arena
                             .root()
@@ -90,7 +91,7 @@ Variations.";
                             .collect::<Vec<NodeId<ToNodeId>>>();
 
         let longest = lcss(&base_pre,
-                           &store.from_arena,
+                           &store.from_arena.borrow(),
                            &diff_pre,
                            &store.to_arena,
                            &eq);

--- a/tests/test_edit_script.rs
+++ b/tests/test_edit_script.rs
@@ -42,7 +42,7 @@ extern crate diffract;
 
 use std::path::Path;
 
-use diffract::ast::{Arena, parse_file};
+use diffract::ast::{parse_file, Arena};
 use diffract::edit_script::{Chawathe96Config, EditScriptGenerator};
 use diffract::matchers::MatchTrees;
 use diffract::myers_matcher::MyersConfig;
@@ -68,16 +68,17 @@ fn check_trees(is_java: bool, filepath1: &str, filepath2: &str) {
     // Generate an edit script.
     let gen_config: Box<EditScriptGenerator<String>> = Box::new(Chawathe96Config::new());
     let edit_script_wrapped = gen_config.generate_script(&mut store);
-    assert!(edit_script_wrapped.is_ok(), "Edit script generator failed to complete.");
+    assert!(edit_script_wrapped.is_ok(),
+            "Edit script generator failed to complete.");
     // Get root nodes.
-    let root_from = store.from_arena.root().unwrap();
+    let root_from = store.from_arena.borrow().root().unwrap();
     let root_to = store.to_arena.root().unwrap();
     // Every reachable node in both ASTs should be mapped. N.B. deleted
     // nodes in the to AST will be in the arena but should not be reachable
     // from the root node.
     let mut count_nodes = 0;
     let mut count_mapped = 0;
-    for node in root_from.breadth_first_traversal(&store.from_arena) {
+    for node in root_from.breadth_first_traversal(&store.from_arena.borrow()) {
         count_nodes += 1;
         assert!(store.contains_from(&node));
         count_mapped += 1;
@@ -99,16 +100,16 @@ fn test_empty_arena() {
     // Lex and parse the input files.
     let lex = Path::new("grammars/calc.l");
     let yacc = Path::new("grammars/calc.y");
-    let ast_from = Arena::new();  // Empty Arena with no root.
+    let ast_from = Arena::new(); // Empty Arena with no root.
     let ast_to = parse_file("tests/empty.calc", lex, yacc).unwrap();
     // Generate mappings between ASTs.
     let matcher_config = MyersConfig::new();
     let mut store = matcher_config.match_trees(ast_from, ast_to);
-    assert!(store.from.is_empty());
-    assert!(store.to.is_empty());
+    assert!(store.from.borrow().is_empty());
+    assert!(store.to.borrow().is_empty());
     // Generate an edit script.
     let gen_config: Box<EditScriptGenerator<String>> = Box::new(Chawathe96Config::new());
-    let _edit_script_wrapped = gen_config.generate_script(&mut store);  // Panic.
+    let _edit_script_wrapped = gen_config.generate_script(&mut store); // Panic.
 }
 
 #[test]
@@ -133,7 +134,7 @@ fn test_one_empty_calc() {
 
 #[test]
 fn test_add_one_calc() {
-    check_trees(false, "tests/add.calc", "tests/one.calc",)
+    check_trees(false, "tests/add.calc", "tests/one.calc")
 }
 
 #[test]

--- a/tests/test_matcher.rs
+++ b/tests/test_matcher.rs
@@ -78,12 +78,12 @@ fn compare_asts_post_edit_script(ty: &Filetype, base_file: &str, diff_file: &str
 
     // Once the edit script has been generated, the mapping between the base
     // and diff ASTs should be a total mapping.
-    assert_eq!(size, mapping.from.len());
-    assert_eq!(size, mapping.to.len());
-    for (key, val) in &mapping.from {
-        assert!(mapping.to.contains_key(&val.0));
-        assert_eq!(*key, mapping.get_from(&val.0).unwrap());
-        assert_eq!(val.0, mapping.get_to(key).unwrap());
+    assert_eq!(size, mapping.from.borrow().len());
+    assert_eq!(size, mapping.to.borrow().len());
+    for (key, val) in mapping.from.borrow().iter() {
+        assert!(mapping.to.borrow().contains_key(&val.0));
+        assert_eq!(key, &mapping.get_from(&val.0).unwrap());
+        assert_eq!(val.0, mapping.get_to(&key).unwrap());
     }
 }
 
@@ -92,7 +92,6 @@ fn test_empty_calc() {
     compare_asts_post_edit_script(&Filetype::CALC, "tests/empty.calc", "tests/one.calc");
     compare_asts_post_edit_script(&Filetype::CALC, "tests/one.calc", "tests/empty.calc");
 }
-
 
 #[test]
 fn test_gt_example() {


### PR DESCRIPTION
This PR adds interior mutability to mapping stores, so that we can pass them to functions without marking them mutable. I would suggest reviewing each commit separately (note there is a separate formatting commit).

**Needs squashing** 