### PR TITLE
Wrap a RefCell around to_arena in MappingStore.

### DIFF
--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -298,7 +298,7 @@ impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Move {
                                  f_node.char_no.unwrap(),
                                  f_node.token_len.unwrap()));
         }
-        let t_node = &store.to_arena[store.get_to(&self.from_node).unwrap()];
+        let t_node = &store.to_arena.borrow()[store.get_to(&self.from_node).unwrap()];
         if t_node.char_no.is_some() {
             to.push(Patch::new(ActionType::MOVE,
                                t_node.char_no.unwrap(),
@@ -315,7 +315,7 @@ impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Update<T> {
                                  f_node.char_no.unwrap(),
                                  f_node.token_len.unwrap()));
         }
-        let t_node = &store.to_arena[store.get_to(&self.node).unwrap()];
+        let t_node = &store.to_arena.borrow()[store.get_to(&self.node).unwrap()];
         if t_node.char_no.is_some() {
             to.push(Patch::new(ActionType::UPDATE,
                                t_node.char_no.unwrap(),
@@ -332,7 +332,7 @@ impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Copy {
                                  f_node.char_no.unwrap(),
                                  f_node.token_len.unwrap()));
         }
-        let t_node = &store.to_arena[store.get_to(&self.from_node).unwrap()];
+        let t_node = &store.to_arena.borrow()[store.get_to(&self.from_node).unwrap()];
         if t_node.char_no.is_some() {
             to.push(Patch::new(ActionType::COPY,
                                t_node.char_no.unwrap(),
@@ -349,7 +349,7 @@ impl<T: Clone + Debug + Eq + 'static> Patchify<T> for Glue {
                                  f_node.char_no.unwrap(),
                                  f_node.token_len.unwrap()));
         }
-        let t_node = &store.to_arena[store.get_to(&self.from_node).unwrap()];
+        let t_node = &store.to_arena.borrow()[store.get_to(&self.from_node).unwrap()];
         if t_node.char_no.is_some() {
             to.push(Patch::new(ActionType::GLUE,
                                t_node.char_no.unwrap(),

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -331,23 +331,23 @@ impl RenderDotfile for MappingStore<String> {
                                      attrs));
             }
         }
-        for id in 0..self.to_arena.size() {
+        for id in 0..self.to_arena.borrow().size() {
             to_node = NodeId::new(id);
             if !self.contains_to(&to_node) {
                 attrs = ", style=filled, fillcolor=lightgrey";
             } else {
                 attrs = "";
             }
-            if self.to_arena[to_node].label.is_empty() {
+            if self.to_arena.borrow()[to_node].label.is_empty() {
                 digraph.push(format!("\tTO{}[label=\"{}\"{}];\n",
                                      id,
-                                     escape_string(self.to_arena[to_node].ty.as_str()),
+                                     escape_string(self.to_arena.borrow()[to_node].ty.as_str()),
                                      attrs));
             } else {
                 digraph.push(format!("\tTO{}[label=\"{} {}\"{}];\n",
                                      id,
-                                     escape_string(self.to_arena[to_node].ty.as_str()),
-                                     escape_string(self.to_arena[to_node].label.as_str()),
+                                     escape_string(self.to_arena.borrow()[to_node].ty.as_str()),
+                                     escape_string(self.to_arena.borrow()[to_node].label.as_str()),
                                      attrs));
             }
         }
@@ -366,7 +366,7 @@ impl RenderDotfile for MappingStore<String> {
         digraph.push(String::from("\tsubgraph clusterTO {\n"));
         digraph.push(String::from("\t\tcolor=black;\n"));
         digraph.push(String::from("\t\tstyle=dashed;\n"));
-        for (e0, e1) in self.to_arena.get_edges() {
+        for (e0, e1) in self.to_arena.borrow().get_edges() {
             line = format!("\t\tTO{} -> TO{}[style=solid, arrowhead=vee, arrowsize=.75];\n",
                            e0.id(),
                            e1.id());

--- a/src/lib/gt_matcher.rs
+++ b/src/lib/gt_matcher.rs
@@ -88,7 +88,7 @@ Code Differencing.";
     /// Match locations in distinct ASTs.
     fn match_trees(&self, base: Arena<T, FromNodeId>, diff: Arena<T, ToNodeId>) -> MappingStore<T> {
         let store = MappingStore::new(base, diff);
-        if store.from_arena.borrow().size() == 0 || store.to_arena.size() == 0 {
+        if store.from_arena.borrow().size() == 0 || store.to_arena.borrow().size() == 0 {
             return store;
         }
         store.push(NodeId::<FromNodeId>::new(0),

--- a/src/lib/myers_matcher.rs
+++ b/src/lib/myers_matcher.rs
@@ -75,7 +75,7 @@ Variations.";
     /// Match locations in distinct ASTs.
     fn match_trees(&self, base: Arena<T, FromNodeId>, diff: Arena<T, ToNodeId>) -> MappingStore<T> {
         let store = MappingStore::new(base, diff);
-        if store.from_arena.borrow().is_empty() || store.to_arena.is_empty() {
+        if store.from_arena.borrow().is_empty() || store.to_arena.borrow().is_empty() {
             return store;
         }
         let base_pre = store.from_arena
@@ -85,15 +85,16 @@ Variations.";
                             .pre_order_traversal(&store.from_arena.borrow())
                             .collect::<Vec<NodeId<FromNodeId>>>();
         let diff_pre = store.to_arena
+                            .borrow()
                             .root()
                             .unwrap()
-                            .pre_order_traversal(&store.to_arena)
+                            .pre_order_traversal(&store.to_arena.borrow())
                             .collect::<Vec<NodeId<ToNodeId>>>();
 
         let longest = lcss(&base_pre,
                            &store.from_arena.borrow(),
                            &diff_pre,
-                           &store.to_arena,
+                           &store.to_arena.borrow(),
                            &eq);
         for &(n1, n2) in &longest {
             store.push(n1, n2, &MappingType::ANCHOR);

--- a/src/lib/sequence.rs
+++ b/src/lib/sequence.rs
@@ -158,25 +158,25 @@ mod tests {
 
     fn assert_sequence_correct<T: Clone + Debug + Eq>(store: MappingStore<T>, expected: &[T]) {
         if expected.is_empty() {
-            assert!(lcss(&vec![], &store.from_arena.borrow(), &vec![], &store.to_arena, &eq).is_empty());
+            assert!(lcss(&vec![], &store.from_arena.borrow(), &vec![], &store.to_arena.borrow(), &eq).is_empty());
             return;
         }
         assert!(!store.from_arena.borrow().is_empty());
-        assert!(!store.to_arena.is_empty());
+        assert!(!store.to_arena.borrow().is_empty());
         let base_root = store.from_arena.borrow().root().unwrap();
         let base = base_root.children(&store.from_arena.borrow())
                             .collect::<Vec<NodeId<FromNodeId>>>();
-        let diff_root = store.to_arena.root().unwrap();
-        let diff = diff_root.children(&store.to_arena)
+        let diff_root = store.to_arena.borrow().root().unwrap();
+        let diff = diff_root.children(&store.to_arena.borrow())
                             .collect::<Vec<NodeId<ToNodeId>>>();
         let longest = lcss(&base,
                            &store.from_arena.borrow(),
                            &diff,
-                           &store.to_arena,
+                           &store.to_arena.borrow(),
                            &eq);
         for (i, value) in longest.iter().enumerate() {
             assert_eq!(expected[i], store.from_arena.borrow()[value.0].ty);
-            assert_eq!(expected[i], store.to_arena[value.1].ty);
+            assert_eq!(expected[i], store.to_arena.borrow()[value.1].ty);
         }
     }
 

--- a/tests/test_edit_script.rs
+++ b/tests/test_edit_script.rs
@@ -72,7 +72,7 @@ fn check_trees(is_java: bool, filepath1: &str, filepath2: &str) {
             "Edit script generator failed to complete.");
     // Get root nodes.
     let root_from = store.from_arena.borrow().root().unwrap();
-    let root_to = store.to_arena.root().unwrap();
+    let root_to = store.to_arena.borrow().root().unwrap();
     // Every reachable node in both ASTs should be mapped. N.B. deleted
     // nodes in the to AST will be in the arena but should not be reachable
     // from the root node.
@@ -86,7 +86,7 @@ fn check_trees(is_java: bool, filepath1: &str, filepath2: &str) {
     assert_eq!(count_nodes, count_mapped);
     count_nodes = 0;
     count_mapped = 0;
-    for node in root_to.breadth_first_traversal(&store.to_arena) {
+    for node in root_to.breadth_first_traversal(&store.to_arena.borrow()) {
         count_nodes += 1;
         assert!(store.contains_to(&node));
         count_mapped += 1;


### PR DESCRIPTION
The feature branch `new-edit-script-tests` adds some more tests (mostly integration tests so far) for the edit script generator and contains a (so far partial) fix for the bug in the generator. The code we recently merged into `master`, which wraps a `RefCell` around some elements of the `MappingStore` struct, is especially difficult to merge into the feature branch, and last time I tried I had to give up and abort the merge.

Part of the difficulty is that half-way through the merge we need to add an extra `RefCell` into the `MappingStore` struct (or alternatively mark a number of stores as mutable). Rather than do that in the merge, this PR isolates that change so that we can merge it into master now. 