### PR TITLE
Action module improvements

### DIFF
--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -756,8 +756,6 @@ mod test {
         assert_eq!(ins1, ins1);
         assert_eq!(ins2, ins2);
         assert_ne!(ins1, ins2);
-        assert_ne!(del1, ins1);
-        assert_ne!(del2, ins2);
         let mov1 = Move::new(NodeId::new(6), NodeId::new(2), 0); // Swap "INT 100" and "INT 99".
         let upd1 = Update::new(NodeId::new(0), "Expr", String::from("*"));
         actions1.push(del1);
@@ -766,7 +764,6 @@ mod test {
         actions1.push(ins2);
         actions1.push(mov1);
         actions1.push(upd1);
-        assert_ne!(mov1, upd1);
         assert_eq!(6, actions1.size());
         // Second edit script.
         let mut arena2 = create_arena();

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -434,6 +434,11 @@ impl<T: Clone + Debug + Eq> EditScript<T> {
     pub fn clear(&mut self) {
         self.actions.clear();
     }
+
+    /// Return the number of actions in this list.
+    pub fn size(&self) -> usize {
+        self.actions.len()
+    }
 }
 
 impl<T: Clone> RenderJson for EditScript<T> {
@@ -639,6 +644,7 @@ mod test {
         actions.push(ins2);
         actions.push(mov);
         actions.push(upd);
+        assert_eq!(6, actions.size());
         // Apply action list.
         actions.apply(&mut arena).unwrap();
         let format2 = "\"Expr\" *
@@ -674,6 +680,7 @@ mod test {
         actions.push(del);
         actions.push(ins);
         actions.push(upd);
+        assert_eq!(3, actions.size());
         // Apply action list.
         actions.apply(&mut arena).unwrap();
         let format2 = "\"Expr\" *
@@ -701,6 +708,7 @@ mod test {
         actions.push(ins2);
         actions.push(mov);
         actions.push(upd);
+        assert_eq!(6, actions.size());
         let expected = String::from(
             "\"actions\": [
     {


### PR DESCRIPTION
This PR:

  * Adds a new `size()` method, 
  * Implements the `Debug` trait, and
  * Implements the `PartialEq` 

for `EditScript` objects. The last of these is complicated, because we store edit scripts as a vector of boxed traits. These need to be downcast before calling `eq()` and we need to avoid unbounded recursion in the `eq()` method.

See also [this SO question](https://stackoverflow.com/questions/48952627/implementing-partialeq-on-a-boxed-trait).