### PR TITLE
Edit script fixes

### DIFF
--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -198,7 +198,9 @@ impl<T: Clone + PartialEq, U: PartialEq + Copy> Arena<T, U> {
         if root.children(self).collect::<Vec<NodeId<U>>>().len() > 1 {
             return Err(ArenaError::NodeHasTooManyChildren);
         }
-        self.root = self[root].first_child;
+        let new_root = self[root].first_child.unwrap();
+        self[new_root].parent = None;
+        self.root = Some(new_root);
         self[root].parent = None;
         self[root].first_child = None;
         // Next few assignments should not be necessary.

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -122,7 +122,7 @@ impl<T: Clone, U: PartialEq + Copy> IndexMut<NodeId<U>> for Arena<T, U> {
 }
 
 #[cfg(test)]
-impl<T: Clone> From<Arena<T, ToNodeId>> for Arena<T, FromNodeId> {
+impl<T: Clone + PartialEq> From<Arena<T, ToNodeId>> for Arena<T, FromNodeId> {
     fn from(arena: Arena<T, ToNodeId>) -> Self {
         let coerced = arena.nodes
                            .iter()
@@ -135,7 +135,7 @@ impl<T: Clone> From<Arena<T, ToNodeId>> for Arena<T, FromNodeId> {
 }
 
 #[cfg(test)]
-impl<T: Clone> From<Arena<T, FromNodeId>> for Arena<T, ToNodeId> {
+impl<T: Clone + PartialEq> From<Arena<T, FromNodeId>> for Arena<T, ToNodeId> {
     fn from(arena: Arena<T, FromNodeId>) -> Self {
         let coerced = arena.nodes
                            .iter()
@@ -147,7 +147,7 @@ impl<T: Clone> From<Arena<T, FromNodeId>> for Arena<T, ToNodeId> {
     }
 }
 
-impl<T: Clone, U: PartialEq + Copy> Arena<T, U> {
+impl<T: Clone + PartialEq, U: PartialEq + Copy> Arena<T, U> {
     /// Create an empty `Arena`.
     pub fn new() -> Arena<T, U> {
         Default::default()
@@ -230,6 +230,16 @@ impl<T: Clone, U: PartialEq + Copy> Arena<T, U> {
     /// Return `true` if index is in arena, `false` otherwise.
     pub fn contains(&self, index: NodeId<U>) -> bool {
         index.index < self.nodes.len()
+    }
+
+    /// Test whether this arena contains a node with a given type and label.
+    pub fn contains_type_and_label(&self, ty: T, label: &str) -> bool {
+        for n in &self.nodes {
+            if ty == n.ty && label == n.label {
+                return true;
+            }
+        }
+        false
     }
 
     /// Return a queue of `NodeId`s sorted by height.
@@ -496,7 +506,7 @@ impl<U: PartialEq + Copy> NodeId<U> {
     /// actually removed from the arena, because `NodeId`s should be immutable.
     /// This means that if you detach the root of the tree, any iterator will
     /// still be able to reach the root (but not any of the other nodes).
-    pub fn detach<T: Clone>(&self, arena: &mut Arena<T, U>) -> ArenaResult {
+    pub fn detach<T: Clone + PartialEq>(&self, arena: &mut Arena<T, U>) -> ArenaResult {
         if !arena.contains(*self) {
             return Err(ArenaError::NodeIdNotFound);
         }
@@ -523,7 +533,7 @@ impl<U: PartialEq + Copy> NodeId<U> {
     /// actually removed from the arena, because `NodeId`s should be immutable.
     /// This means that if you detach the root of the tree, any iterator will
     /// still be able to reach the root (but not any of the other nodes).
-    pub fn detach_with_children<T: Clone>(&self, arena: &mut Arena<T, U>) -> ArenaResult {
+    pub fn detach_with_children<T: Clone + PartialEq>(&self, arena: &mut Arena<T, U>) -> ArenaResult {
         self.detach(arena)?;
         let ids = self.children(arena).collect::<Vec<NodeId<U>>>();
         for id in ids {
@@ -533,7 +543,7 @@ impl<U: PartialEq + Copy> NodeId<U> {
     }
 
     /// Make self the next (i.e. last) child of another.
-    pub fn make_child_of<T: Clone>(&self, parent: NodeId<U>, arena: &mut Arena<T, U>) -> ArenaResult {
+    pub fn make_child_of<T: Clone + PartialEq>(&self, parent: NodeId<U>, arena: &mut Arena<T, U>) -> ArenaResult {
         if self.index >= arena.size() || parent.index >= arena.size() {
             return Err(ArenaError::NodeIdNotFound);
         }
@@ -556,7 +566,11 @@ impl<U: PartialEq + Copy> NodeId<U> {
     /// Attach children to given node
     /// This would copy the subtree from the to_node
     /// And then attach it to the self node.
-    pub fn copy_subtree<T: Clone>(self, _to_node: NodeId<U>, position: u16, _arena: &mut Arena<T, U>) -> ArenaResult {
+    pub fn copy_subtree<T: Clone + PartialEq>(self,
+                                              _to_node: NodeId<U>,
+                                              position: u16,
+                                              _arena: &mut Arena<T, U>)
+                                              -> ArenaResult {
         let current_node = _arena[_to_node].clone();
 
         let mut _new_node_made = _arena.new_node(current_node.ty,
@@ -590,7 +604,11 @@ impl<U: PartialEq + Copy> NodeId<U> {
     ///
     /// Children are numbered from zero, so `nth == 0` makes `self` the *first*
     /// child of `parent`.
-    pub fn make_nth_child_of<T: Clone>(&self, parent: NodeId<U>, nth: u16, arena: &mut Arena<T, U>) -> ArenaResult {
+    pub fn make_nth_child_of<T: Clone + PartialEq>(&self,
+                                                   parent: NodeId<U>,
+                                                   nth: u16,
+                                                   arena: &mut Arena<T, U>)
+                                                   -> ArenaResult {
         if !arena.contains(*self) {
             return Err(ArenaError::NodeIdNotFound);
         }
@@ -1442,6 +1460,16 @@ mod tests {
         assert!(arena.contains(n1));
         assert!(!arena.contains(NodeId { index: 1,
                                          phantom: PhantomData, }));
+    }
+
+    #[test]
+    fn contains_type_and_label() {
+        let arena = &mut Arena::<&str, FromNodeId>::new();
+        let _ = arena.new_node("1", String::from("INT"), None, None, None, None);
+        assert!(arena.contains_type_and_label("1", "INT"));
+        assert!(!arena.contains_type_and_label("0", "INT"));
+        assert!(!arena.contains_type_and_label("1", "FLOAT"));
+        assert!(!arena.contains_type_and_label("0", "FLOAT"));
     }
 
     #[test]

--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -153,13 +153,13 @@ impl Chawathe96Config {
             from_in_order.insert(a);
             to_in_order.insert(b);
         }
-        // 6. For each a in s1, b in s2 such that (a, b) in store (M) but
+        // 6. For each a in s1, b in s2 such that (a, b) in store (M') but
         // (a, b) not in lcs: (i) let k = find_pos(b); (ii) append MOV(a, w, k)
         // to the script and apply MOV(a, w, k) to T_1; (iii) Mark a, b as "in
-        // order".
+        // order". Note, the paper says M (for the store), but should say M'.
         for a in &s1 {
             for b in &s2 {
-                if store.is_mapped_by_matcher(a, b) && !lcs.contains(&(*a, *b)) {
+                if store.is_mapped(a, b) && !lcs.contains(&(*a, *b)) {
                     let k = self.find_pos(store, *b, from_in_order, to_in_order);
                     let mut mov = Move::new(*a, w, k);
                     debug!("Edit script align_children: MOV {:?} {} Parent: {:?} {} Child: {}",

--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -196,7 +196,8 @@ impl Chawathe96Config {
         let x_pos = x.get_child_position(&store.to_arena.borrow()).unwrap();
         // 3. Find v in T_2, where v is the rightmost sibling of x that is to
         // the left of x and is marked "in order".
-        let v = x.children(&store.to_arena.borrow()).take(x_pos)
+        let v = siblings.iter()
+                 .take(x_pos)
                  .filter(|c| to_in_order.contains(c))
                  .last();
         if v.is_none() {

--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -45,7 +45,11 @@ use action::{ApplyAction, Delete, EditScript, Insert, Move, Update};
 use ast::{ArenaError, FromNodeId, NodeId, ToNodeId};
 use matchers::{EditScriptResult, MappingStore, MappingType};
 
-const TMP_ROOT: &str = "_____DIFFRACT_TMP_ROOT";
+/// Label to use when introducing temporary root nodes in an AST.
+///
+/// Temporary root nodes should be removed before the edit script generator
+/// completes. This constant is exposed for use in integration tests.
+pub const TMP_ROOT: &str = "_____DIFFRACT_TMP_ROOT";
 
 /// Given a matching between two ASTs, generate a complete edit script.
 ///

--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -283,6 +283,9 @@ impl<T: Clone + Debug + Default + Eq + 'static> EditScriptGenerator<T> for Chawa
         let mut script: EditScript<T> = EditScript::new();
         let mut from_in_order: HashSet<NodeId<FromNodeId>> = HashSet::new();
         let mut to_in_order: HashSet<NodeId<ToNodeId>> = HashSet::new();
+        if store.from_arena.borrow().is_empty() && store.to_arena.borrow().is_empty() {
+            return Ok(script);
+        }
         // Combined update, insert, align and move phases.
         // 2. Visit the nodes of T_2 in breadth-first order.
         assert!(store.from_arena.borrow().root().is_some(),
@@ -439,7 +442,6 @@ mod tests {
     use ast::Arena;
 
     #[test]
-    #[ignore]
     fn test_chawathe96_empty_asts() {
         let ast_from = Arena::<u8, FromNodeId>::new();
         let ast_to = Arena::<u8, ToNodeId>::new();
@@ -503,7 +505,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_chawathe96_single_update() {
         let mut ast_from = Arena::<&'static str, FromNodeId>::new();
         let root_from = ast_from.new_node("Expr", String::from("+"), None, None, None, None);

--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -45,6 +45,8 @@ use action::{ApplyAction, Delete, EditScript, Insert, Move, Update};
 use ast::{ArenaError, FromNodeId, NodeId, ToNodeId};
 use matchers::{EditScriptResult, MappingStore, MappingType};
 
+const TMP_ROOT: &str = "_____DIFFRACT_TMP_ROOT";
+
 /// Given a matching between two ASTs, generate a complete edit script.
 ///
 /// This trait should usually be implemented on configuration objects that
@@ -93,6 +95,7 @@ impl Chawathe96Config {
         Default::default()
     }
 
+    /// Align children of w (From AST) and x (To AST) which are out of order.
     fn align_children<T: Clone + Debug + Eq + 'static>(&self,
                                                        store: &MappingStore<T>,
                                                        w: NodeId<FromNodeId>,
@@ -105,8 +108,12 @@ impl Chawathe96Config {
         // a, w in store.from_arena (T_1 in paper).
         // b, x in store.to_arena (T_2 in paper).
         debug!("align_children({}, {})", w, x);
+        // If neither node has any children there is nothing to align. This
+        // optimisation does not appear in the paper.
         if w.is_leaf(&store.from_arena.borrow()) && x.is_leaf(&store.to_arena.borrow()) {
-            debug!("{} and {} both leaf nodes.", w, x);
+            debug!("align_children: {:?} and {:?} both leaf nodes.",
+                   store.from_arena.borrow()[w],
+                   store.to_arena.borrow()[x]);
             return Ok(());
         }
         // 1. Mark all children of w and all children of x "out of order".
@@ -178,7 +185,8 @@ impl Chawathe96Config {
                                                  to_in_order: &HashSet<NodeId<ToNodeId>>)
                                                  -> u16 {
         // 1. Let y=p(x) in T_2 and let w be the partner of x in T_1.
-        // N.B. w seems to be unused in the algorithm.
+        // N.B. w seems to be unused in the algorithm and y is not needed in
+        // this implementation.
         let y = store.to_arena.borrow()[x].parent().unwrap();
         // 2. If x is the leftmost child of y that is marked "in order" return
         // 0 (the paper says 1 but we count child nodes from 0).
@@ -197,9 +205,10 @@ impl Chawathe96Config {
         // 3. Find v in T_2, where v is the rightmost sibling of x that is to
         // the left of x and is marked "in order".
         let v = siblings.iter()
-                 .take(x_pos)
-                 .filter(|c| to_in_order.contains(c))
-                 .last();
+                        .take(x_pos)
+                        .filter(|c| to_in_order.contains(c))
+                        .last();
+        // This check is in GumTree and ChangeDistiller, but not in the paper.
         if v.is_none() {
             debug!("find_pos({}) <- 0. No right-most sibling in order.", x);
             return 0;
@@ -212,11 +221,11 @@ impl Chawathe96Config {
         // "in order". Return i + 1.
         let u_p = store.from_arena.borrow()[u].parent().unwrap();
         let u_pos = u.get_child_position(&store.from_arena.borrow()).unwrap();
-        let ret = u_p.children(&store.from_arena.borrow()).take(u_pos)
-                     .filter(|c| from_in_order.contains(c))
-                     .count() as u16 + 1;
-        debug!("find_pos({}) <- {}", x, ret);
-        ret
+        let position = u_p.children(&store.from_arena.borrow()).take(u_pos)
+                          .filter(|c| from_in_order.contains(c))
+                          .count() as u16 + 1;
+        debug!("find_pos({}) <- {}", x, position);
+        position
     }
 
     fn lcss<T: Clone + Debug + Eq + 'static>(&self,
@@ -265,7 +274,7 @@ impl Chawathe96Config {
     }
 }
 
-impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Config {
+impl<T: Clone + Debug + Default + Eq + 'static> EditScriptGenerator<T> for Chawathe96Config {
     /// This function implements the optimal algorithm of Chawathe et al. (1996).
     /// Variable names as in Figures 8 and 9 of the paper.
     /// Will panic if either `Arena` in `store` is empty (and has no root node).
@@ -276,51 +285,68 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
         let mut to_in_order: HashSet<NodeId<ToNodeId>> = HashSet::new();
         // Combined update, insert, align and move phases.
         // 2. Visit the nodes of T_2 in breadth-first order.
-        let root_to = store.to_arena.borrow().root().unwrap();
+        assert!(store.from_arena.borrow().root().is_some(),
+                "'from' AST has no root node.");
+        assert!(store.to_arena.borrow().root().is_some(),
+                "'to' AST has no root node.");
+        // Check for unmatched root nodes. Chawathe et al. (1996) says: If the
+        // roots of T_1 and T_2 are not matched in M, then we add new (dummy)
+        // root nodes x to T_1 and y to T_2, and add (x; y)to M. The old root of
+        // T_1 is made the lone child of x and the old root of T_2 is made the
+        // lone child of y. Hereafter we assume without loss of generality that
+        // the roots of T_1 and T_2 are matched in M.
+        let mut fake_roots = false;
+        if !store.is_mapped(&store.from_arena.borrow().root().unwrap(),
+                            &store.to_arena.borrow().root().unwrap())
+        {
+            fake_roots = true;
+            assert!(!store.from_arena
+                          .borrow()
+                          .contains_type_and_label(Default::default(), TMP_ROOT),
+                    "'from' AST already contains a node like TMP_ROOT.");
+            let new_from_root = store.from_arena.borrow_mut().new_node(Default::default(),
+                                                                       String::from(TMP_ROOT),
+                                                                       None,
+                                                                       None,
+                                                                       None,
+                                                                       None);
+            store.from_arena.borrow_mut().new_root(new_from_root)?;
+            assert!(!store.to_arena
+                          .borrow()
+                          .contains_type_and_label(Default::default(), TMP_ROOT),
+                    "'to' AST already contains a node like TMP_ROOT.");
+            let new_to_root = store.to_arena.borrow_mut().new_node(Default::default(),
+                                                                   String::from(TMP_ROOT),
+                                                                   None,
+                                                                   None,
+                                                                   None,
+                                                                   None);
+            store.to_arena.borrow_mut().new_root(new_to_root)?;
+            store.push(new_from_root, new_to_root, &MappingType::EDIT);
+        }
         let root_from = store.from_arena.borrow().root().unwrap();
+        let root_to = store.to_arena.borrow().root().unwrap();
         // (a) Let x be the current node in the breadth-first search of T_2
         // and let y be the parent of x. Let z be the partner of y in M'.
         for x in root_to.breadth_first_traversal(&store.to_arena.borrow()) {
             let mut w = root_from; // Overwritten later.
                                    // Insertion phase.
-            if !store.contains_to(&x) && x.is_root(&store.to_arena.borrow()) {
-                // Handle root nodes separately. This branch is most likely to
-                // be used when the "from" and "to" ASTs have been parsed
-                // into different grammars.
-                let k = self.find_pos(store, x, &from_in_order, &to_in_order);
-                debug!("Edit script: INS {:?} {} No parent",
-                       store.to_arena.borrow()[x].ty,
-                       store.to_arena.borrow()[x].label);
-                w = store.from_arena
-                         .borrow_mut()
-                         .new_node(store.to_arena.borrow()[x].ty.clone(),
-                                   store.to_arena.borrow()[x].label.clone(),
-                                   store.to_arena.borrow()[x].col_no,
-                                   store.to_arena.borrow()[x].line_no,
-                                   store.to_arena.borrow()[x].char_no,
-                                   store.to_arena.borrow()[x].token_len);
-                store.push(w, x, &MappingType::EDIT);
-                let mut ins = Insert::new(w, None, k);
-                ins.apply(&mut store.from_arena.borrow_mut())?;
-                script.push(ins);
-            } else if !store.contains_to(&x) {
+             if !store.contains_to(&x) {
                 let y = store.to_arena.borrow()[x].parent().unwrap();
                 let z = store.get_from(&y).unwrap();
                 // (b) if x has no partner in M': i. let k<-find_pos(x),
                 let k = self.find_pos(store, x, &from_in_order, &to_in_order);
-                debug!("Edit script: INS {:?} {} Parent: {:?} {}",
-                       store.to_arena.borrow()[x].ty,
-                       store.to_arena.borrow()[x].label,
-                       store.from_arena.borrow()[z].ty,
-                       store.from_arena.borrow()[z].label);
-                w = store.from_arena
-                         .borrow_mut()
-                         .new_node(store.to_arena.borrow()[x].ty.clone(),
-                                   store.to_arena.borrow()[x].label.clone(),
-                                   store.to_arena.borrow()[x].col_no,
-                                   store.to_arena.borrow()[x].line_no,
-                                   store.to_arena.borrow()[x].char_no,
-                                   store.to_arena.borrow()[x].token_len);
+                debug!("Edit script: INS {:?} Parent: {:?}",
+                       store.to_arena.borrow()[x],
+                       store.from_arena.borrow()[z]);
+                let w = store.from_arena
+                             .borrow_mut()
+                             .new_node(store.to_arena.borrow()[x].ty.clone(),
+                                       store.to_arena.borrow()[x].label.clone(),
+                                       store.to_arena.borrow()[x].col_no,
+                                       store.to_arena.borrow()[x].line_no,
+                                       store.to_arena.borrow()[x].char_no,
+                                       store.to_arena.borrow()[x].token_len);
                 // iii. Add (w, x) to M' and apply INS((w, a, v(x)), z, k) to T_1.
                 store.push(w, x, &MappingType::EDIT);
                 // ii. Append INS((w, a, v(x)), z, k) to E for new identifier w
@@ -335,12 +361,10 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
                 w = store.get_from(&x).unwrap();
                 let v = store.from_arena.borrow()[w].parent().unwrap();
                 // ii. if value_of(w) != value_of(x):
-                if store.from_arena.borrow()[w].ty != store.to_arena.borrow()[x].ty {
-                    debug!("Edit script: UPD {:?} {} -> {:?} {}",
-                           store.from_arena.borrow()[w].ty,
-                           store.from_arena.borrow()[w].label,
-                           store.to_arena.borrow()[x].ty,
-                           store.to_arena.borrow()[x].label);
+                if store.from_arena.borrow()[w].label != store.to_arena.borrow()[x].label {
+                    debug!("Edit script: UPD {:?} -> {:?}",
+                           store.from_arena.borrow()[w],
+                           store.to_arena.borrow()[x]);
                     let mut upd = Update::new(w,
                                               store.to_arena.borrow()[x].ty.clone(),
                                               store.to_arena.borrow()[x].label.clone());
@@ -395,6 +419,15 @@ impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe96Confi
             }
         }
         actions.apply(&mut store.from_arena.borrow_mut())?;
+        if fake_roots {
+            debug!("Removing fake roots.");
+            let tmp_from_root = store.from_arena.borrow().root().unwrap();
+            let tmp_to_root = store.to_arena.borrow().root().unwrap();
+            store.from_arena.borrow_mut().delete_root()?;
+            store.to_arena.borrow_mut().delete_root()?;
+            store.remove(&tmp_from_root, &tmp_to_root);
+        }
+        debug_assert!(store.is_isomorphic(root_from, root_to));
         Ok(script)
     }
 }

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -278,7 +278,7 @@ impl<'a, T: PartialEq + Copy> Labeller<'a, NodeId<T>, EdgeId<T>> for Arena<Strin
     }
 }
 
-impl<'a, T: Clone, U: Clone + PartialEq + Copy> GraphWalk<'a, NodeId<U>, EdgeId<U>> for Arena<T, U> {
+impl<'a, T: Clone + PartialEq, U: Clone + PartialEq + Copy> GraphWalk<'a, NodeId<U>, EdgeId<U>> for Arena<T, U> {
     fn nodes(&self) -> Nodes<'a, NodeId<U>> {
         Owned((0..self.size()).map(NodeId::new).collect())
     }

--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -202,7 +202,7 @@ mod tests {
     }
 
     // Assert that `queue` is in sorted order and has the same size `arena`.
-    fn assert_sorted<T: Clone>(queue: &HeightQueue<FromNodeId>, arena: &Arena<T, FromNodeId>) {
+    fn assert_sorted<T: Clone + PartialEq>(queue: &HeightQueue<FromNodeId>, arena: &Arena<T, FromNodeId>) {
         let mut expected = arena.size();
         if expected == 0 {
             assert!(queue.is_empty());

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -163,18 +163,6 @@ impl<T: Clone + Debug + Eq + 'static> MappingStore<T> {
         self.get_to(from).map_or(false, |x| x == *to)
     }
 
-    /// Test whether `from` is mapped to `to` by the matcher.
-    /// As opposed to the edit script generator.
-    pub fn is_mapped_by_matcher(&self, from: &NodeId<FromNodeId>, to: &NodeId<ToNodeId>) -> bool {
-        if !self.contains_from(from) {
-            return false;
-        }
-        match self.from.borrow().get(from) {
-            None => false,
-            Some(&(val, ref ty)) => val == *to && *ty != MappingType::EDIT,
-        }
-    }
-
     /// Two sub-trees are isomorphic if they have the same structure.
     ///
     /// Two single-node trees are isomorphic if they have the same types
@@ -402,29 +390,6 @@ mod tests {
         assert!(!store.is_mapped(&NodeId::new(2), &NodeId::new(1)));
         assert!(!store.is_mapped(&NodeId::new(2), &NodeId::new(2)));
         assert!(!store.is_mapped(&NodeId::new(2), &NodeId::new(3)));
-    }
-
-    #[test]
-    fn is_mapped_by_matcher() {
-        let mult = create_mult_arena();
-        let plus = create_plus_arena();
-        let store = MappingStore::new(plus, Arena::<&'static str, ToNodeId>::from(mult));
-        store.push(NodeId::new(0), NodeId::new(0), &MappingType::CONTAINER);
-        store.push(NodeId::new(2), NodeId::new(4), &MappingType::EDIT);
-        assert!(store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(0)));
-        // Not mapped.
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(1)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(2)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(3)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(0), &NodeId::new(4)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(1), &NodeId::new(1)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(1), &NodeId::new(2)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(1), &NodeId::new(3)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(1), &NodeId::new(4)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(2), &NodeId::new(1)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(2), &NodeId::new(2)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(2), &NodeId::new(3)));
-        assert!(!store.is_mapped_by_matcher(&NodeId::new(2), &NodeId::new(4)));
     }
 
     #[test]

--- a/tests/CommentMinimal.java
+++ b/tests/CommentMinimal.java
@@ -1,0 +1,2 @@
+public /* Multiline 2 */ class /* Multiline 3 */ Comment {
+}

--- a/tests/HelloMinimal.java
+++ b/tests/HelloMinimal.java
@@ -1,0 +1,4 @@
+public class Hello {
+    void main() {
+    }
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -40,7 +40,7 @@
 
 extern crate diffract;
 
-use diffract::edit_script::{Chawathe96Config, EditScriptGenerator};
+use diffract::edit_script::{Chawathe96Config, EditScriptGenerator, TMP_ROOT};
 use diffract::matchers::MatchTrees;
 use diffract::parser::{get_lexer, get_parser, parse_file};
 
@@ -96,4 +96,17 @@ pub fn check_files(path1: &str, path2: &str, matcher: Box<MatchTrees<String>>) {
                path1,
                path2);
 
+    // Test 3: check that `TMP_ROOT` is not found in the tree. This text is
+    // used when the `from` and `to` trees have roots with different types or
+    // labels. It should be removed before the edit script generator completes.
+    for id in root_from.breadth_first_traversal(&store.from_arena.borrow()) {
+        if TMP_ROOT == store.from_arena.borrow()[id].label {
+            assert!(false, "TMP_ROOT not removed from {:?}", path1);
+        }
+    }
+    for id in root_to.breadth_first_traversal(&store.to_arena.borrow()) {
+        if TMP_ROOT == store.to_arena.borrow()[id].label {
+            assert!(false, "TMP_ROOT not removed from {:?}", path2);
+        }
+    }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -82,4 +82,18 @@ pub fn check_files(path1: &str, path2: &str, matcher: Box<MatchTrees<String>>) {
     assert_eq!(count_nodes, count_mapped,
                "Final mapping not total for files: {} and {}.",
                path1, path2);
+    // Test 2: final from and to ASTs should be isomorphic.
+    // Isomorphism is defined strictly, as there being no differences in the two
+    // trees, except in their node identifiers. As a belt-and-braces check, we
+    // also check that pretty-printed versions of both trees are identical.
+    assert!(store.is_isomorphic(root_from, root_to),
+            "ASTs not isomorphic for files: {} and {}.",
+            path1,
+            path2);
+    assert_eq!(format!("{:?}", store.from_arena.borrow()),
+               format!("{:?}", store.to_arena.borrow()),
+               "ASTs not isomorphic for files: {} and {}.",
+               path1,
+               path2);
+
 }

--- a/tests/test_edit_script.rs
+++ b/tests/test_edit_script.rs
@@ -108,7 +108,6 @@ fn test_short_text_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_plain_text_null() {
     check_files("tests/lorem1.txt",
                 "tests/lorem2.txt",
@@ -123,7 +122,6 @@ fn test_plain_text_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_wiki_null() {
     // Example from wikipedia.
     check_files("tests/wiki1.txt",
@@ -140,7 +138,6 @@ fn test_wiki_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_empty_one_calc_null() {
     check_files("tests/empty.calc",
                 "tests/one.calc",
@@ -155,7 +152,6 @@ fn test_empty_one_calc_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_one_two_calc_null() {
     check_files("tests/one.calc",
                 "tests/two.calc",
@@ -170,7 +166,6 @@ fn test_one_two_calc_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_one_add_calc_null() {
     check_files("tests/one.calc",
                 "tests/add.calc",
@@ -185,7 +180,6 @@ fn test_one_add_calc_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_add_mult_calc_null() {
     check_files("tests/add.calc",
                 "tests/mult.calc",
@@ -200,7 +194,6 @@ fn test_add_mult_calc_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_one_empty_calc_null() {
     check_files("tests/one.calc",
                 "tests/empty.calc",
@@ -215,7 +208,6 @@ fn test_one_empty_calc_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_add_one_calc_null() {
     check_files("tests/add.calc",
                 "tests/one.calc",
@@ -230,7 +222,6 @@ fn test_add_one_calc_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_mult_add_calc_null() {
     check_files("tests/mult.calc",
                 "tests/add.calc",
@@ -245,7 +236,6 @@ fn test_mult_add_calc_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_test0_test1_java_null() {
     check_files("tests/Test0.java",
                 "tests/Test1.java",
@@ -260,7 +250,6 @@ fn test_test0_test1_java_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_empty_hello_java_null() {
     check_files("tests/Empty.java",
                 "tests/Hello.java",
@@ -275,7 +264,6 @@ fn test_empty_hello_java_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_test1_test0_java_null() {
     check_files("tests/Test1.java",
                 "tests/Test0.java",
@@ -290,7 +278,6 @@ fn test_test1_test0_java_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_hello_empty_java_null() {
     check_files("tests/Hello.java",
                 "tests/Empty.java",
@@ -308,7 +295,6 @@ fn test_hello_empty_java_myers() {
 // different grammars.
 
 #[test]
-#[ignore]
 fn test_empty_one_both_null() {
     check_files("tests/empty.calc",
                 "tests/Empty.java",
@@ -316,7 +302,6 @@ fn test_empty_one_both_null() {
 }
 
 #[test]
-#[ignore]
 fn test_add_hello_both_null() {
     check_files("tests/add.calc",
                 "tests/Hello.java",
@@ -341,7 +326,6 @@ fn test_hello_test1_myers() {
 }
 
 #[test]
-#[ignore]
 fn test_hello_test0_myers() {
     check_files("tests/Hello.java",
                 "tests/Test0.txt",

--- a/tests/test_edit_script.rs
+++ b/tests/test_edit_script.rs
@@ -50,10 +50,23 @@ mod common;
 use common::check_files;
 
 #[test]
+fn test_both_arenas_empty() {
+    let ast_from = Arena::new();
+    let ast_to = Arena::new();
+    // Generate mappings between ASTs.
+    let matcher_config = MyersConfig::new();
+    let store = matcher_config.match_trees(ast_from, ast_to);
+    assert!(store.from.borrow().is_empty());
+    assert!(store.to.borrow().is_empty());
+    // Generate an edit script.
+    let gen_config: Box<EditScriptGenerator<String>> = Box::new(Chawathe96Config::new());
+    let _edit_script_wrapped = gen_config.generate_script(&store);
+}
+
+#[test]
 #[should_panic]
-fn test_empty_arena() {
-    // Lex and parse the input files.
-    let ast_from = Arena::new(); // Empty Arena with no root.
+fn test_from_arena_empty() {
+    let ast_from = Arena::new();
     let ast_to = parse_file("tests/empty.calc", &get_lexer("grammars/calc.l"), &get_parser("grammars/calc.y")).unwrap();
     // Generate mappings between ASTs.
     let matcher_config = MyersConfig::new();
@@ -66,7 +79,21 @@ fn test_empty_arena() {
 }
 
 #[test]
-#[ignore]
+#[should_panic]
+fn test_to_arena_empty() {
+    let ast_from = parse_file("tests/empty.calc", &get_lexer("grammars/calc.l"), &get_parser("grammars/calc.y")).unwrap();
+    let ast_to = Arena::new();
+    // Generate mappings between ASTs.
+    let matcher_config = MyersConfig::new();
+    let store = matcher_config.match_trees(ast_from, ast_to);
+    assert!(store.from.borrow().is_empty());
+    assert!(store.to.borrow().is_empty());
+    // Generate an edit script.
+    let gen_config: Box<EditScriptGenerator<String>> = Box::new(Chawathe96Config::new());
+    gen_config.generate_script(&store).ok(); // Panic.
+}
+
+#[test]
 fn test_short_text_null() {
     check_files("tests/short1.txt",
                 "tests/short2.txt",

--- a/tests/test_edit_script.rs
+++ b/tests/test_edit_script.rs
@@ -329,6 +329,20 @@ fn test_comment_hello_myers() {
 }
 
 #[test]
+fn test_comment_minimal_hello_minimal_myers() {
+    check_files("tests/CommentMinimal.java",
+                "tests/HelloMinimal.java",
+                Box::new(MyersConfig::new()))
+}
+
+#[test]
+fn test_hello_minimal_comment_minimal_myers() {
+    check_files("tests/HelloMinimal.java",
+                "tests/CommentMinimal.java",
+                Box::new(MyersConfig::new()))
+}
+
+#[test]
 fn test_short1_wiki2_myers() {
     check_files("tests/short1.txt",
                 "tests/wiki2.txt",

--- a/tests/test_hqueue.rs
+++ b/tests/test_hqueue.rs
@@ -45,7 +45,7 @@ use diffract::hqueue::HeightQueue;
 use diffract::parser::{get_lexer, get_parser, parse_file};
 
 // Assert that `queue` is in sorted order and has the same size `arena`.
-fn assert_sorted<T: Clone>(queue: &HeightQueue<FromNodeId>, arena: &Arena<T, FromNodeId>) {
+fn assert_sorted<T: Clone + PartialEq>(queue: &HeightQueue<FromNodeId>, arena: &Arena<T, FromNodeId>) {
     let mut expected = arena.size();
     if expected == 0 {
         assert!(queue.is_empty());


### PR DESCRIPTION
This PR contains a number of fixes for the edit script generator. It is probably easier to review commit-by-commit, and the commit messages contain details of each fix.

The only commit that needs some extra information is 5bfe448a1f18d3f41a7a2dda0ea1e569bf0bebc0 which "fixes" something that looked like a bug, but was actually something that makes no difference to the algorithms, but produced very confusing debug output. Here is an example from master branch: 

[master_edit.pdf](https://github.com/softdevteam/diffract/files/1794497/master_edit.pdf)
 
In this example, we have diff'd two files of different file types, meaning that in the original ASTs the two trees will have had different roots (with different types and labels). The Chawathe et al. 96 algorithm assumes that trees have the same root, and so while the edit script generators is running, we add in temporary roots to both trees, and remove them once the edit script is complete. The mistake here was to leave the new root of the tree with a parent, which is the temporary root node. You can see in the PDF that the temporary root is coloured grey, meaning that it has been deleted from the AST, but because it is still referred to it appears in the tree.

Here is the same example in this branch:

[feature_edit.pdf](https://github.com/softdevteam/diffract/files/1794508/feature_edit.pdf)

The ignored tests (the long run of tests for every pair of example files in the `tests/` directory) also pass.