### PR TITLE
Decorate ASTs with hashes of each node (needed by GumTree).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ docopt = "0.7.0"
 dot = "0.1.2"
 env_logger = "0.4.2"
 log = "0.3.7"
+rust-crypto = "0.2.36"
 rustc-serialize = "0.3"
 term = "0.4.5"
 cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }

--- a/src/lib/edit_script.rs
+++ b/src/lib/edit_script.rs
@@ -55,7 +55,7 @@ pub const TMP_ROOT: &str = "_____DIFFRACT_TMP_ROOT";
 ///
 /// This trait should usually be implemented on configuration objects that
 /// define thresholds and weights for a given algorithm.
-pub trait EditScriptGenerator<T: Clone + Debug + Eq + 'static> {
+pub trait EditScriptGenerator<T: Clone + Debug + Eq + ToString + 'static> {
     /// Given a matching between two ASTs, generate a complete edit script.
     fn generate_script(&self, store: &MappingStore<T>) -> EditScriptResult<T>;
 }
@@ -76,7 +76,7 @@ impl Chawathe98Config {
     }
 }
 
-impl<T: Clone + Debug + Eq + 'static> EditScriptGenerator<T> for Chawathe98Config {
+impl<T: Clone + Debug + Eq + ToString + 'static> EditScriptGenerator<T> for Chawathe98Config {
     /// This function should generate the edit script for GLUE and COPY
     fn generate_script(&self, _store: &MappingStore<T>) -> EditScriptResult<T> {
         Ok(EditScript::new())
@@ -100,7 +100,7 @@ impl Chawathe96Config {
     }
 
     /// Align children of w (From AST) and x (To AST) which are out of order.
-    fn align_children<T: Clone + Debug + Eq + 'static>(&self,
+    fn align_children<T: Clone + Debug + Eq + ToString + 'static>(&self,
                                                        store: &MappingStore<T>,
                                                        w: NodeId<FromNodeId>,
                                                        x: NodeId<ToNodeId>,
@@ -183,7 +183,7 @@ impl Chawathe96Config {
     }
 
     /// Find the position of node x in to_arena.
-    fn find_pos<T: Clone + Debug + Eq + 'static>(&self,
+    fn find_pos<T: Clone + Debug + Eq + ToString + 'static>(&self,
                                                  store: &MappingStore<T>,
                                                  x: NodeId<ToNodeId>,
                                                  from_in_order: &HashSet<NodeId<FromNodeId>>,
@@ -234,7 +234,7 @@ impl Chawathe96Config {
         position
     }
 
-    fn lcss<T: Clone + Debug + Eq + 'static>(&self,
+    fn lcss<T: Clone + Debug + Eq + ToString + 'static>(&self,
                                              store: &MappingStore<T>,
                                              seq1: &[NodeId<FromNodeId>],
                                              seq2: &[NodeId<ToNodeId>])
@@ -280,7 +280,7 @@ impl Chawathe96Config {
     }
 }
 
-impl<T: Clone + Debug + Default + Eq + 'static> EditScriptGenerator<T> for Chawathe96Config {
+impl<T: Clone + Debug + Default + Eq + ToString + 'static> EditScriptGenerator<T> for Chawathe96Config {
     /// This function implements the optimal algorithm of Chawathe et al. (1996).
     /// Variable names as in Figures 8 and 9 of the paper.
     /// Will panic if either `Arena` in `store` is empty (and has no root node).

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -126,11 +126,11 @@ fn read_file(path: &str) -> Result<String, EmitterError> {
 /// If the terminal foreground cannot be changed or reset by the
 /// [term](https://crates.io/crates/term) crate, this function will panic.
 /// However, `term` is cross-platform so this failure case should be rare.
-pub fn write_diff_to_stdout<T: Clone + Debug + Eq>(store: &MappingStore<T>,
-                                                   script: &EditScript<T>,
-                                                   from_path: &str,
-                                                   to_path: &str)
-                                                   -> Result<(), EmitterError> {
+pub fn write_diff_to_stdout<T: Clone + Debug + Eq + ToString>(store: &MappingStore<T>,
+                                                              script: &EditScript<T>,
+                                                              from_path: &str,
+                                                              to_path: &str)
+                                                              -> Result<(), EmitterError> {
     let colours = build_colour_map();
     // Turn edit script and mappings into hunks of related patches.
     let mut from_patches: Vec<Patch> = vec![];

--- a/src/lib/fingerprint.rs
+++ b/src/lib/fingerprint.rs
@@ -1,0 +1,236 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any
+// person obtaining a copy of this software, associated documentation and/or
+// data (collectively the "Software"), free of charge and under any and all
+// copyright rights in the Software, and any and all patent rights owned or
+// freely licensable by each licensor hereunder covering either (i) the
+// unmodified Software as contributed to or provided by such licensor, or (ii)
+// the Larger Works (as defined below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a “Larger Work” to which the Software
+// is contributed by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create
+// derivative works of, display, perform, and distribute the Software and make,
+// use, sell, offer for sale, import, export, have made, and have sold the
+// Software and the Larger Work(s), and to sublicense the foregoing rights on
+// either these or other terms.
+//
+// This license is subject to the following condition: The above copyright
+// notice and either this complete permission notice or at a minimum a reference
+// to the UPL must be included in all copies or substantial portions of the
+// Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#![warn(missing_docs)]
+
+/// This module implements the algorithm described in M. Chilowicz, E. Duris, G.
+/// Roussel (2009) Syntax Tree Fingerprinting: A Foundation For Source Code
+/// Similarity Detection.
+
+use std::collections::hash_map::DefaultHasher;
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+
+use crypto::digest::Digest;
+use crypto::md5::Md5;
+
+use ast::{Arena, FromOrToNodeId, NodeId};
+use matchers::MappingStore;
+
+/// Type alias for hashes stored in Arenas.
+pub type HashType = u64;
+
+const BASE: u64 = 33;
+
+/// Symbol used in calculating static hashes of AST nodes.
+///
+/// See `ast:: to_static_hash_string`.
+pub const OPEN_SYMBOL: &str = "[(";
+
+/// Symbol used in calculating static hashes of AST nodes.
+///
+/// See `ast:: to_static_hash_string`.
+pub const CLOSE_SYMBOL: &str = ")]";
+
+/// Symbol used in calculating static hashes of AST nodes.
+///
+/// See `ast:: to_static_hash_string`.
+pub const SEPARATE_SYMBOL: &str = "@@";
+
+fn calculate_hash<T: Hash>(t: &T) -> HashType {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish() as HashType
+}
+
+fn standard_hash<T: Clone + Eq + Hash, U: PartialEq + Copy>(id: &NodeId<U>, arena: &Arena<T, U>) -> HashType {
+    calculate_hash(&arena[*id].ty) + BASE + calculate_hash(&arena[*id].label)
+}
+
+fn in_seed<T: Clone + Eq + Hash + ToString, U: PartialEq + Copy>(id: &NodeId<U>,
+                                                                 arena: &Arena<T, U>)
+                                                                 -> String {
+    String::from(OPEN_SYMBOL) + &arena[*id].label + SEPARATE_SYMBOL + &arena[*id].ty.to_string()
+}
+
+fn out_seed<T: Clone + Eq + Hash + ToString, U: PartialEq + Copy>(id: &NodeId<U>,
+                                                                  arena: &Arena<T, U>)
+                                                                  -> String {
+    arena[*id].ty.to_string() + SEPARATE_SYMBOL + &arena[*id].label + CLOSE_SYMBOL
+}
+
+/// Convert a byte array (from digest) to integer.
+fn bytes_to_int(b: &[u8]) -> HashType {
+    debug_assert_eq!(4, b.len(), "Byte array from digest has length {}", b.len());
+    HashType::from(b[3]) & 0xff | (HashType::from(b[2]) & 0xff) << 8 | (HashType::from(b[1]) & 0xff) << 16
+    | (HashType::from(b[0]) & 0xff) << 24
+}
+
+/// Integer exponent function, returns `b**e`.
+fn fpow(b: u64, e: u64) -> u64 {
+    if e == 1 {
+        return b;
+    }
+    let mut base = b;
+    let mut exp = e;
+    let mut result: u64 = 1;
+    while exp > 0 {
+        if (exp & 1) != 0 {
+            result *= base;
+        }
+        exp >>= 1;
+        base *= base;
+    }
+    result
+}
+
+/// Apply an action to an AST node.
+pub trait HashGenerator<T: Clone + Debug + Eq + Hash + ToString> {
+    /// Hash a string.
+    fn hash(&mut self, msg: &str) -> HashType;
+    /// Generate a hash for a leaf node in an `Arena`.
+    ///
+    /// The type of `id` tells the implementation which `Arena` is to be used.
+    fn hash_leaf(&mut self, id: FromOrToNodeId, store: &MappingStore<T>) -> HashType;
+    /// Generate a hash for a branch node in a given `Arena`.
+    ///
+    /// The type of `id` tells the implementation which `Arena` is to be used.
+    fn hash_branch(&mut self, id: FromOrToNodeId, store: &MappingStore<T>) -> HashType;
+}
+
+/// The md5 rolling hash generator from GumTree.
+pub struct Md5HashGenerator {
+    generator: Md5,
+}
+
+impl Md5HashGenerator {
+    /// Create a new md5 rolling hash generator.
+    pub fn new() -> Md5HashGenerator {
+        Md5HashGenerator { generator: Md5::new(), }
+    }
+}
+
+impl<T: Clone + Debug + Eq + Hash + ToString> HashGenerator<T> for Md5HashGenerator {
+    fn hash(&mut self, msg: &str) -> HashType {
+        self.generator.input_str(msg);
+        let mut result_arr: Vec<u8> = vec![];
+        self.generator.result(result_arr.as_mut_slice());
+        self.generator.reset();
+        bytes_to_int(result_arr.as_slice()) as HashType
+    }
+
+    fn hash_leaf(&mut self, id_enum: FromOrToNodeId, store: &MappingStore<T>) -> HashType {
+        match id_enum {
+            FromOrToNodeId::FromNodeId(id) => {
+                BASE * HashGenerator::<T>::hash(self, &in_seed(&id, &store.from_arena.borrow()))
+                + HashGenerator::<T>::hash(self, &out_seed(&id, &store.from_arena.borrow()))
+            }
+            FromOrToNodeId::ToNodeId(id) => {
+                BASE * HashGenerator::<T>::hash(self, &in_seed(&id, &store.to_arena.borrow()))
+                + HashGenerator::<T>::hash(self, &out_seed(&id, &store.to_arena.borrow()))
+            }
+        }
+    }
+
+    fn hash_branch(&mut self, id_enum: FromOrToNodeId, store: &MappingStore<T>) -> HashType {
+        match id_enum {
+            FromOrToNodeId::FromNodeId(id) => {
+                let mut size = HashType::from(id.size(&store.from_arena.borrow()));
+                let mut hash = HashGenerator::<T>::hash(self, &in_seed(&id, &store.from_arena.borrow()))
+                               * fpow(BASE, size);
+                for child in id.children(&store.from_arena.borrow()) {
+                    size -= HashType::from(child.size(&store.from_arena.borrow())) * 2;
+                    debug_assert!(child.get_hash(&store.from_arena.borrow()).is_some());
+                    hash += child.get_hash(&store.from_arena.borrow()).unwrap()
+                }
+                hash + HashGenerator::<T>::hash(self, &out_seed(&id, &store.from_arena.borrow()))
+            }
+            FromOrToNodeId::ToNodeId(id) => {
+                let mut size = HashType::from(id.size(&store.to_arena.borrow()));
+                let mut hash = HashGenerator::<T>::hash(self, &in_seed(&id, &store.to_arena.borrow()))
+                               * fpow(BASE, size);
+                for child in id.children(&store.to_arena.borrow()) {
+                    size -= HashType::from(child.size(&store.to_arena.borrow())) * 2;
+                    debug_assert!(child.get_hash(&store.to_arena.borrow()).is_some());
+                    hash += child.get_hash(&store.to_arena.borrow()).unwrap()
+                }
+                hash + HashGenerator::<T>::hash(self, &out_seed(&id, &store.to_arena.borrow()))
+            }
+        }
+    }
+}
+
+/// Decorate the `from` AST with fingerprints.
+pub fn apply_fingerprint<T: Clone + Debug + Eq + Hash + ToString>(gen: &mut HashGenerator<T>,
+                                                                  store: &MappingStore<T>) {
+    debug_assert!(store.from_arena.borrow().root().is_some());
+    for child in store.from_arena
+                      .borrow()
+                      .root()
+                      .unwrap()
+                      .post_order_traversal(&store.from_arena.borrow())
+    {
+        if child.is_leaf(&store.from_arena.borrow()) {
+            child.set_hash(Some(gen.hash_leaf(FromOrToNodeId::FromNodeId(child), store)),
+                           &mut store.from_arena.borrow_mut());
+        } else {
+            child.set_hash(Some(gen.hash_branch(FromOrToNodeId::FromNodeId(child), store)),
+                           &mut store.from_arena.borrow_mut());
+        }
+    }
+}
+
+/// Decorate the `from` and `to` ASTs with fingerprints.
+pub fn apply_fingerprint_both<T: Clone + Debug + Eq + Hash + ToString>(gen: &mut HashGenerator<T>,
+                                                                       store: &MappingStore<T>) {
+    apply_fingerprint(gen, store);
+    debug_assert!(store.to_arena.borrow().root().is_some());
+    for child in store.to_arena
+                      .borrow()
+                      .root()
+                      .unwrap()
+                      .post_order_traversal(&store.to_arena.borrow())
+    {
+        if child.is_leaf(&store.to_arena.borrow()) {
+            child.set_hash(Some(gen.hash_leaf(FromOrToNodeId::ToNodeId(child), store)),
+                           &mut store.to_arena.borrow_mut());
+        } else {
+            child.set_hash(Some(gen.hash_branch(FromOrToNodeId::ToNodeId(child), store)),
+                           &mut store.to_arena.borrow_mut());
+        }
+    }
+}

--- a/src/lib/gt_matcher.rs
+++ b/src/lib/gt_matcher.rs
@@ -70,7 +70,7 @@ impl GumTreeConfig {
     }
 }
 
-impl<T: Clone + Debug + Eq + 'static> MatchTrees<T> for GumTreeConfig {
+impl<T: Clone + Debug + Eq + ToString + 'static> MatchTrees<T> for GumTreeConfig {
     /// Describe this matcher for the user.
     fn describe(&self) -> String {
         let desc = "

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -39,6 +39,7 @@
 #![feature(try_from)]
 
 extern crate cfgrammar;
+extern crate crypto;
 extern crate dot;
 #[macro_use]
 extern crate log;
@@ -95,3 +96,6 @@ pub mod sequence;
 ///
 /// Induced, pruning algorithms currently implemented.
 pub mod chawathe98_matcher;
+
+/// Fingerprinting algorithms for tree isomorphism tests.
+pub mod fingerprint;

--- a/src/lib/myers_matcher.rs
+++ b/src/lib/myers_matcher.rs
@@ -60,7 +60,7 @@ impl MyersConfig {
     }
 }
 
-impl<T: Clone + Debug + Eq + 'static> MatchTrees<T> for MyersConfig {
+impl<T: Clone + Debug + Eq + ToString + 'static> MatchTrees<T> for MyersConfig {
     /// Describe this matcher for the user.
     fn describe(&self) -> String {
         let desc = "

--- a/src/lib/null_matcher.rs
+++ b/src/lib/null_matcher.rs
@@ -59,15 +59,17 @@ impl NullConfig {
     }
 }
 
-impl<T: Clone + Debug + Eq + 'static> MatchTrees<T> for NullConfig {
+impl<T: Clone + Debug + Eq + ToString + 'static> MatchTrees<T> for NullConfig {
     /// Describe this matcher for the user.
     fn describe(&self) -> String {
-        let desc = "This matcher performs no matching operations.";
-        String::from(desc)
+        String::from("This matcher performs no matching operations.")
     }
 
     /// Perform no matching operations.
-    fn match_trees(&self, base: Arena<T, FromNodeId>, diff: Arena<T, ToNodeId>) -> MappingStore<T> {
+    fn match_trees(&self,
+                   base: Arena<T, FromNodeId>,
+                   diff: Arena<T, ToNodeId>)
+                   -> MappingStore<T> {
         MappingStore::new(base, diff)
     }
 }

--- a/src/lib/sequence.rs
+++ b/src/lib/sequence.rs
@@ -156,7 +156,8 @@ mod tests {
         arena1[*n1].label == arena2[*n2].label && arena1[*n1].ty == arena2[*n2].ty
     }
 
-    fn assert_sequence_correct<T: Clone + Debug + Eq>(store: MappingStore<T>, expected: &[T]) {
+    fn assert_sequence_correct<T: Clone + Debug + Eq + ToString>(store: MappingStore<T>,
+                                                                 expected: &[T]) {
         if expected.is_empty() {
             assert!(lcss(&vec![], &store.from_arena.borrow(), &vec![], &store.to_arena.borrow(), &eq).is_empty());
             return;
@@ -180,7 +181,7 @@ mod tests {
         }
     }
 
-    fn create_mapping_store<T: Clone + Default + Debug + Eq + 'static>(base: &[T], diff: &[T]) -> MappingStore<T> {
+    fn create_mapping_store<T: Clone + Default + Debug + Eq + ToString + 'static>(base: &[T], diff: &[T]) -> MappingStore<T> {
         let mut base_arena: Arena<T, FromNodeId> = Arena::new();
         let mut from_id: NodeId<FromNodeId>;
         let mut to_id: NodeId<ToNodeId>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ extern crate diffract;
 use diffract::ast;
 use diffract::edit_script;
 use diffract::emitters;
+use diffract::fingerprint;
 use diffract::gt_matcher;
 use diffract::myers_matcher;
 use diffract::matchers::MatchTrees;
@@ -373,8 +374,17 @@ fn main() {
         write_dotfile_to_disk(&args.flag_dot[1], &ast_diff);
     }
 
-    // Generate mappings between ASTs.
+    // Create a mapping store.
     let mapping = matcher_config.match_trees(ast_base, ast_diff);
+
+    // If the matcher needs it, set the fingerprint (hash) of each node in the
+    // from and to ASTs.
+    if args.flag_matcher == Some(Matchers::GumTree) {
+        let mut hash_generator = fingerprint::Md5HashGenerator::new();
+        fingerprint::apply_fingerprint_both(&mut hash_generator, &mapping);
+    }
+
+    // Generate mappings between ASTs.
     if args.flag_map.is_some() {
         let map_file = args.flag_map.unwrap();
         info!("Creating dot representation of mapping {:?}.", map_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,20 +375,20 @@ fn main() {
     }
 
     // Create a mapping store.
-    let mapping = matcher_config.match_trees(ast_base, ast_diff);
+    let store = matcher_config.match_trees(ast_base, ast_diff);
 
     // If the matcher needs it, set the fingerprint (hash) of each node in the
     // from and to ASTs.
     if args.flag_matcher == Some(Matchers::GumTree) {
         let mut hash_generator = fingerprint::Md5HashGenerator::new();
-        fingerprint::apply_fingerprint_both(&mut hash_generator, &mapping);
+        fingerprint::apply_fingerprint_both(&mut hash_generator, &store);
     }
 
     // Generate mappings between ASTs.
     if args.flag_map.is_some() {
         let map_file = args.flag_map.unwrap();
         info!("Creating dot representation of mapping {:?}.", map_file);
-        write_dotfile_to_disk(&map_file, &mapping);
+        write_dotfile_to_disk(&map_file, &store);
     }
 
     // Generate edit script.
@@ -415,7 +415,7 @@ fn main() {
         config
     }
 
-    let edit_script = match generator_config.generate_script(&mapping) {
+    let edit_script = match generator_config.generate_script(&store) {
         Ok(script) => script,
         Err(err) => consume_edit_script_err(&err),
     };
@@ -423,13 +423,13 @@ fn main() {
         let edit_file = args.flag_store.unwrap();
         info!("Creating dot representation of edit script {:?}.",
               edit_file);
-        write_dotfile_to_disk(&edit_file, &mapping);
+        write_dotfile_to_disk(&edit_file, &store);
     }
 
     // Generate output.
     if args.flag_output.is_none() || args.flag_output == Some(Output::Terminal) {
         info!("Writing terminal output to STDOUT.");
-        consume_emitter_err(emitters::write_diff_to_stdout(&mapping,
+        consume_emitter_err(emitters::write_diff_to_stdout(&store,
                                                            &edit_script,
                                                            &args.arg_base_file,
                                                            &args.arg_diff_file),
@@ -439,10 +439,10 @@ fn main() {
         return;
     } else if args.flag_output == Some(Output::JSON) {
         info!("Writing JSON output to STDOUT.");
-        consume_emitter_err(emitters::write_json_to_stream(Box::new(stdout()), &mapping, &edit_script),
+        consume_emitter_err(emitters::write_json_to_stream(Box::new(stdout()), &store, &edit_script),
                             "STDOUT");
     }
 
-    debug!("Final 'from' AST:\n{:?}", mapping.from_arena.borrow());
-    debug!("Final 'to' AST:\n{:?}", mapping.to_arena.borrow());
+    debug!("Final 'from' AST:\n{:?}", store.from_arena.borrow());
+    debug!("Final 'to' AST:\n{:?}", store.to_arena.borrow());
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -95,8 +95,14 @@ pub fn check_files(path1: &str, path2: &str, matcher: Box<MatchTrees<String>>) {
                "ASTs not isomorphic for files: {} and {}.",
                path1,
                path2);
-
-    // Test 3: check that `TMP_ROOT` is not found in the tree. This text is
+    // Test 3: final from and to ASTs should be isomorphic.
+    // In this test isomorphism is determined by examining the hashes of the
+    // two trees.
+    assert!(store.is_isomorphic_hash(root_from, root_to),
+            "ASTs not isomorphic for files: {} and {}.",
+            path1,
+            path2);
+    // Test 4: check that `TMP_ROOT` is not found in the tree. This text is
     // used when the `from` and `to` trees have roots with different types or
     // labels. It should be removed before the edit script generator completes.
     for id in root_from.breadth_first_traversal(&store.from_arena.borrow()) {


### PR DESCRIPTION
The fingerprinting module implements the algorithm described in M. Chilowicz, E. Duris, G. Roussel (2009) Syntax Tree Fingerprinting: A Foundation For Source Code Similarity Detection. This is used by the GumTree matcher algorithm.
    
The implementation here is based closely on the GumTree implementation. 

Implement [to_short_string()](https://github.com/GumTreeDiff/gumtree/blob/066d138201acb3c457bafb131a5a33fd820d1919/core/src/main/java/com/github/gumtreediff/tree/AbstractTree.java#L245) and [to_static_hash_string()](https://github.com/GumTreeDiff/gumtree/blob/066d138201acb3c457bafb131a5a33fd820d1919/core/src/main/java/com/github/gumtreediff/tree/AbstractTree.java#L228) on `NodeId`. Compute [tree isomorphism based on hashes](https://github.com/GumTreeDiff/gumtree/blob/066d138201acb3c457bafb131a5a33fd820d1919/core/src/main/java/com/github/gumtreediff/tree/AbstractTree.java#L124) (as a method on matcher objects). The hash generator here is based on the default GumTree hash generator, i.e. the [Md5RollingHashGenerator](https://github.com/GumTreeDiff/gumtree/blob/develop/core/src/main/java/com/github/gumtreediff/tree/hash/RollingHashGenerator.java#L68) class.
    
In addition, we create a new enum in ast.rs, `FromOrToNodeId`, which can be used by functions and methods which need to match on either a `NodeId<FromNodeId>` or a `NodeId<ToNodeId>` type.

Integration tests check tree isomorphism based on hashes, and fingerprints are added to ASTs only if the user has selected the GumTree matcher.

