### PR TITLE
Refactor unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ path = "src/lib/mod.rs"
 [build-dependencies]
 glob = "0.2.11"
 
+[dev-dependencies]
+serde = "1.0.55"
+serde_derive = "1.0.55"
+serde-xml-rs = "0.2.1"
+
 [dependencies]
 docopt = "0.7.0"
 dot = "0.1.2"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 max_width = 100
 indent_style = "Visual"
+trailing_comma = "Never"

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -102,7 +102,10 @@ pub trait Patchify<T: Clone + fmt::Debug + ToString> {
     /// Turn object into a `Patch`. Non-terminal nodes are ignored.
     fn patchify(&self, store: &MappingStore<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>);
     /// Turn object into a 'Patch'.
-    fn patchify_chawathe98(&self, store: &MappingStoreGraph<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>);
+    fn patchify_chawathe98(&self,
+                           store: &MappingStoreGraph<T>,
+                           from: &mut Vec<Patch>,
+                           to: &mut Vec<Patch>);
 }
 
 /// A list of actions to be applied.
@@ -213,7 +216,7 @@ impl Glue {
     pub fn new(from: NodeId<FromNodeId>, parent: NodeId<FromNodeId>, position: u16) -> Glue {
         Glue { from_node: from,
                node: parent,
-               pos : position}
+               pos: position, }
     }
 }
 
@@ -310,7 +313,10 @@ impl<T: Clone + fmt::Debug + Eq + ToString> Patchify<T> for Delete {
                                  node.token_len.unwrap()));
         }
     }
-    fn patchify_chawathe98(&self, store: &MappingStoreGraph<T>, from: &mut Vec<Patch>, _: &mut Vec<Patch>) {
+    fn patchify_chawathe98(&self,
+                           store: &MappingStoreGraph<T>,
+                           from: &mut Vec<Patch>,
+                           _: &mut Vec<Patch>) {
         let node = &store.from_arena.borrow()[self.node];
         if node.char_no.is_some() {
             from.push(Patch::new(ActionType::DELETE,
@@ -330,7 +336,10 @@ impl<T: Clone + fmt::Debug + Eq + ToString> Patchify<T> for Insert {
         }
     }
 
-    fn patchify_chawathe98(&self, store: &MappingStoreGraph<T>, _: &mut Vec<Patch>, to: &mut Vec<Patch>) {
+    fn patchify_chawathe98(&self,
+                           store: &MappingStoreGraph<T>,
+                           _: &mut Vec<Patch>,
+                           to: &mut Vec<Patch>) {
         let node = &store.from_arena.borrow()[self.node];
         if node.char_no.is_some() {
             to.push(Patch::new(ActionType::INSERT,
@@ -356,7 +365,10 @@ impl<T: Clone + fmt::Debug + Eq + ToString + 'static> Patchify<T> for Move {
         }
     }
 
-    fn patchify_chawathe98(&self, store: &MappingStoreGraph<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>) {
+    fn patchify_chawathe98(&self,
+                           store: &MappingStoreGraph<T>,
+                           from: &mut Vec<Patch>,
+                           to: &mut Vec<Patch>) {
         let f_node = &store.from_arena.borrow()[self.from_node];
         if f_node.char_no.is_some() {
             from.push(Patch::new(ActionType::MOVE,
@@ -388,7 +400,10 @@ impl<T: Clone + fmt::Debug + Eq + ToString + 'static> Patchify<T> for Update<T> 
         }
     }
 
-    fn patchify_chawathe98(&self, store: &MappingStoreGraph<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>) {
+    fn patchify_chawathe98(&self,
+                           store: &MappingStoreGraph<T>,
+                           from: &mut Vec<Patch>,
+                           to: &mut Vec<Patch>) {
         let f_node = &store.from_arena.borrow()[self.node];
         if f_node.char_no.is_some() {
             from.push(Patch::new(ActionType::UPDATE,
@@ -420,7 +435,10 @@ impl<T: Clone + fmt::Debug + Eq + ToString + 'static> Patchify<T> for Copy {
         }
     }
 
-    fn patchify_chawathe98(&self, store: &MappingStoreGraph<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>) {
+    fn patchify_chawathe98(&self,
+                           store: &MappingStoreGraph<T>,
+                           from: &mut Vec<Patch>,
+                           to: &mut Vec<Patch>) {
         let f_node = &store.from_arena.borrow()[self.from_node];
         if f_node.char_no.is_some() {
             from.push(Patch::new(ActionType::COPY,
@@ -452,7 +470,10 @@ impl<T: Clone + fmt::Debug + Eq + ToString + 'static> Patchify<T> for Glue {
         }
     }
 
-    fn patchify_chawathe98(&self, store: &MappingStoreGraph<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>) {
+    fn patchify_chawathe98(&self,
+                           store: &MappingStoreGraph<T>,
+                           from: &mut Vec<Patch>,
+                           to: &mut Vec<Patch>) {
         let f_node = &store.from_arena.borrow()[self.from_node];
         if f_node.char_no.is_some() {
             from.push(Patch::new(ActionType::GLUE,
@@ -466,7 +487,6 @@ impl<T: Clone + fmt::Debug + Eq + ToString + 'static> Patchify<T> for Glue {
                                t_node.token_len.unwrap()));
         }
     }
-
 }
 
 impl<T: Clone + fmt::Debug + Eq + PartialEq + ToString> ApplyAction<T> for Delete {
@@ -586,7 +606,10 @@ impl<T: Clone + fmt::Debug + Eq + ToString> Patchify<T> for EditScript<T> {
         }
     }
 
-    fn patchify_chawathe98(&self, store: &MappingStoreGraph<T>, from: &mut Vec<Patch>, to: &mut Vec<Patch>) {
+    fn patchify_chawathe98(&self,
+                           store: &MappingStoreGraph<T>,
+                           from: &mut Vec<Patch>,
+                           to: &mut Vec<Patch>) {
         for action in &self.actions {
             action.patchify_chawathe98(store, from, to);
         }
@@ -620,30 +643,18 @@ impl<T: Clone + fmt::Debug + Eq + PartialEq + ToString + 'static> ApplyAction<T>
 #[cfg(test)]
 mod test {
     use super::*;
-
-    fn create_arena() -> Arena<&'static str, FromNodeId> {
-        let mut arena = Arena::new();
-        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
-        let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
-        n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("Expr", String::from("*"), None, None, None, None);
-        n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node("INT", String::from("3"), None, None, None, None);
-        n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node("INT", String::from("4"), None, None, None, None);
-        n4.make_child_of(n2, &mut arena).unwrap();
-        arena
-    }
+    use test_common::create_mult_arena;
 
     #[test]
     fn apply_delete_leaf() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
     \"INT\" 3
     \"INT\" 4
 ";
+
         assert_eq!(format1, format!("{:?}", arena));
         let mut del1 = Delete::new(NodeId::new(3));
         del1.apply(&mut arena).unwrap();
@@ -659,7 +670,7 @@ mod test {
     #[test]
     #[should_panic]
     fn apply_delete_branch() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -673,7 +684,7 @@ mod test {
 
     #[test]
     fn apply_insert() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let n5 = arena.new_node("INT", String::from("100"), None, None, None, None);
         let format1 = "\"Expr\" +
   \"INT\" 1
@@ -696,7 +707,7 @@ mod test {
 
     #[test]
     fn apply_insert_new_root() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let n5 = arena.new_node("Expr", String::from("-"), None, None, None, None);
         let format1 = "\"Expr\" +
   \"INT\" 1
@@ -719,7 +730,7 @@ mod test {
 
     #[test]
     fn apply_move() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -740,7 +751,7 @@ mod test {
 
     #[test]
     fn apply_update() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         assert_eq!(5, arena.size());
         let format1 = "\"Expr\" +
   \"INT\" 1
@@ -762,7 +773,7 @@ mod test {
 
     #[test]
     fn apply_to_list1() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -803,7 +814,7 @@ mod test {
 
     #[test]
     fn apply_to_list2() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -841,7 +852,7 @@ mod test {
 
     #[test]
     fn apply_partial_eq() {
-        let mut arena1 = create_arena();
+        let mut arena1 = create_mult_arena();
         let n5 = arena1.new_node("INT", String::from("100"), None, None, None, None);
         let n6 = arena1.new_node("INT", String::from("99"), None, None, None, None);
         // Create action list.
@@ -868,7 +879,7 @@ mod test {
         assert!(!actions1.is_empty());
         assert_eq!(6, actions1.size());
         // Second edit script.
-        let mut arena2 = create_arena();
+        let mut arena2 = create_mult_arena();
         let n7 = arena2.new_node("INT", String::from("2"), None, None, None, None);
         let mut actions2: EditScript<&str> = EditScript::new();
         assert!(actions2.is_empty());

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -64,7 +64,7 @@ pub enum ActionType {
     /// Copy takes the node or subtree 'from tree' and and copies it into 'to tree'.
     COPY,
     /// GLUE takes a subtree/node 'from tree' and inserts it into 'to tree'
-    GLUE,
+    GLUE
 }
 
 /// Apply an action to an AST node.
@@ -114,7 +114,7 @@ pub trait Patchify<T: Clone + fmt::Debug + ToString> {
 /// `apply()` on each element.
 #[derive(Debug)]
 pub struct EditScript<T: fmt::Debug + PartialEq> {
-    actions: Vec<Box<ApplyAction<T>>>,
+    actions: Vec<Box<ApplyAction<T>>>
 }
 
 /// Delete a node from a given AST.
@@ -122,7 +122,7 @@ pub struct EditScript<T: fmt::Debug + PartialEq> {
 /// It is only valid to delete leaf nodes.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Delete {
-    node: NodeId<FromNodeId>,
+    node: NodeId<FromNodeId>
 }
 
 /// Insert a new node into an AST as the `position`th child of an existing node.
@@ -132,7 +132,7 @@ pub struct Insert {
     node: NodeId<FromNodeId>,
     nth_child: u16,
     /// New parent in to-arena.
-    new_parent: Option<NodeId<FromNodeId>>,
+    new_parent: Option<NodeId<FromNodeId>>
 }
 
 /// Move a node from one place to another within an AST.
@@ -140,7 +140,7 @@ pub struct Insert {
 pub struct Move {
     from_node: NodeId<FromNodeId>,
     parent: NodeId<FromNodeId>,
-    pos: u16,
+    pos: u16
 }
 
 /// Update the data inside an AST node.
@@ -148,7 +148,7 @@ pub struct Move {
 pub struct Update<T: Clone + fmt::Debug> {
     node: NodeId<FromNodeId>,
     ty: T,
-    label: String,
+    label: String
 }
 
 /// Copy a subtree from one place to another with an AST.
@@ -156,7 +156,7 @@ pub struct Update<T: Clone + fmt::Debug> {
 pub struct Copy {
     from_node: NodeId<FromNodeId>,
     parent: NodeId<FromNodeId>,
-    pos: u16,
+    pos: u16
 }
 
 /// Glue a subtree from one place to another with an AST.
@@ -164,7 +164,7 @@ pub struct Copy {
 pub struct Glue {
     from_node: NodeId<FromNodeId>,
     node: NodeId<FromNodeId>,
-    pos: u16,
+    pos: u16
 }
 
 impl Delete {
@@ -182,7 +182,7 @@ impl Insert {
                -> Insert {
         Insert { node,
                  new_parent,
-                 nth_child, }
+                 nth_child }
     }
 }
 
@@ -191,7 +191,7 @@ impl Move {
     pub fn new(from_node: NodeId<FromNodeId>, parent: NodeId<FromNodeId>, pos: u16) -> Move {
         Move { from_node,
                parent,
-               pos, }
+               pos }
     }
 }
 
@@ -207,7 +207,7 @@ impl Copy {
     pub fn new(from_node: NodeId<FromNodeId>, parent: NodeId<FromNodeId>, pos: u16) -> Copy {
         Copy { from_node,
                parent,
-               pos, }
+               pos }
     }
 }
 
@@ -216,7 +216,7 @@ impl Glue {
     pub fn new(from: NodeId<FromNodeId>, parent: NodeId<FromNodeId>, position: u16) -> Glue {
         Glue { from_node: from,
                node: parent,
-               pos: position, }
+               pos: position }
     }
 }
 
@@ -241,7 +241,7 @@ impl RenderJson for Insert {
         json.push(format!("{}\"tree\": {},", &ind_s, self.node.id()));
         match self.new_parent {
             Some(ref p) => json.push(format!("{}\"parent\": {},", &ind_s, p.id())),
-            None => json.push(format!("{}\"parent\": {},", &ind_s, "")),
+            None => json.push(format!("{}\"parent\": {},", &ind_s, ""))
         }
         json.push(format!("{}\"at\": {}", &ind_s, self.nth_child));
         json.push(" ".repeat(indent) + "}");
@@ -503,7 +503,7 @@ impl<T: Clone + fmt::Debug + Eq + PartialEq + ToString> ApplyAction<T> for Inser
     fn apply(&mut self, arena: &mut Arena<T, FromNodeId>) -> ArenaResult {
         match self.new_parent {
             Some(p) => self.node.make_nth_child_of(p, self.nth_child, arena),
-            None => arena.new_root(self.node),
+            None => arena.new_root(self.node)
         }
     }
     impl_compare!();
@@ -826,14 +826,14 @@ mod test {
         // Create action list.
         let mut actions: EditScript<String> = EditScript::new();
         assert!(actions.is_empty());
-        let del = Delete { node: NodeId::new(4), }; // Remove "4".
+        let del = Delete { node: NodeId::new(4) }; // Remove "4".
         let ins = Insert { node: n5,
                            new_parent: Some(NodeId::new(2)),
-                           nth_child: 0, };
+                           nth_child: 0 };
         let upd = Update { // Change "+" to "*".
                            node: NodeId::new(0),
                            ty: "Expr".to_string(),
-                           label: "*".to_string(), };
+                           label: "*".to_string() };
         actions.push(del);
         actions.push(ins);
         actions.push(upd);
@@ -883,14 +883,14 @@ mod test {
         let n7 = arena2.new_node("INT".to_string(), "2".to_string(), None, None, None, None);
         let mut actions2: EditScript<String> = EditScript::new();
         assert!(actions2.is_empty());
-        let del3 = Delete { node: NodeId::new(4), }; // Remove "4".
+        let del3 = Delete { node: NodeId::new(4) }; // Remove "4".
         let ins3 = Insert { node: n7,
                             new_parent: Some(NodeId::new(2)),
-                            nth_child: 0, };
+                            nth_child: 0 };
         let upd2 = Update { // Change "+" to "*".
                             node: NodeId::new(0),
                             ty: "Expr".to_string(),
-                            label: "*".to_string(), };
+                            label: "*".to_string() };
         actions2.push(del3);
         actions2.push(ins3);
         actions2.push(upd2);
@@ -951,7 +951,7 @@ mod test {
         \"tree\": 0,
         \"label\": \"*\"
     }
-]",
+]"
         );
         assert_eq!(expected, actions.render_json(0));
     }

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -685,7 +685,7 @@ mod test {
     #[test]
     fn apply_insert() {
         let mut arena = create_mult_arena();
-        let n5 = arena.new_node("INT", String::from("100"), None, None, None, None);
+        let n5 = arena.new_node("INT".to_string(), "100".to_string(), None, None, None, None);
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -708,7 +708,7 @@ mod test {
     #[test]
     fn apply_insert_new_root() {
         let mut arena = create_mult_arena();
-        let n5 = arena.new_node("Expr", String::from("-"), None, None, None, None);
+        let n5 = arena.new_node("Expr".to_string(), "-".to_string(), None, None, None, None);
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -760,7 +760,7 @@ mod test {
     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
-        let mut upd = Update::new(NodeId::new(2), "Expr", String::from("+"));
+        let mut upd = Update::new(NodeId::new(2), "Expr".to_string(), "+".to_string());
         upd.apply(&mut arena).unwrap();
         let format2 = "\"Expr\" +
   \"INT\" 1
@@ -780,11 +780,11 @@ mod test {
     \"INT\" 3
     \"INT\" 4
 ";
-        let n5 = arena.new_node("INT", String::from("100"), None, None, None, None);
-        let n6 = arena.new_node("INT", String::from("99"), None, None, None, None);
+        let n5 = arena.new_node("INT".to_string(), "100".to_string(), None, None, None, None);
+        let n6 = arena.new_node("INT".to_string(), "99".to_string(), None, None, None, None);
         assert_eq!(format1, format!("{:?}", arena));
         // Create action list.
-        let mut actions: EditScript<&str> = EditScript::new();
+        let mut actions: EditScript<String> = EditScript::new();
         assert!(actions.is_empty());
         let del1 = Delete::new(NodeId::new(3)); // INT 3
         let del2 = Delete::new(NodeId::new(4)); // INT 4
@@ -792,7 +792,7 @@ mod test {
         let ins2 = Insert::new(n6, Some(NodeId::new(2)), 1);
         let mov = Move::new(NodeId::new(6), NodeId::new(2), 0); // Swap "INT 100" and "INT 99".
                                                                 // Change "+"" to "*".
-        let upd = Update::new(NodeId::new(0), "Expr", String::from("*"));
+        let upd = Update::new(NodeId::new(0), "Expr".to_string(), "*".to_string());
         actions.push(del1);
         actions.push(del2);
         actions.push(ins1);
@@ -822,9 +822,9 @@ mod test {
     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
-        let n5 = arena.new_node("INT", String::from("2"), None, None, None, None);
+        let n5 = arena.new_node("INT".to_string(), "2".to_string(), None, None, None, None);
         // Create action list.
-        let mut actions: EditScript<&str> = EditScript::new();
+        let mut actions: EditScript<String> = EditScript::new();
         assert!(actions.is_empty());
         let del = Delete { node: NodeId::new(4), }; // Remove "4".
         let ins = Insert { node: n5,
@@ -832,8 +832,8 @@ mod test {
                            nth_child: 0, };
         let upd = Update { // Change "+" to "*".
                            node: NodeId::new(0),
-                           ty: "Expr",
-                           label: String::from("*"), };
+                           ty: "Expr".to_string(),
+                           label: "*".to_string(), };
         actions.push(del);
         actions.push(ins);
         actions.push(upd);
@@ -853,10 +853,10 @@ mod test {
     #[test]
     fn apply_partial_eq() {
         let mut arena1 = create_mult_arena();
-        let n5 = arena1.new_node("INT", String::from("100"), None, None, None, None);
-        let n6 = arena1.new_node("INT", String::from("99"), None, None, None, None);
+        let n5 = arena1.new_node("INT".to_string(), "100".to_string(), None, None, None, None);
+        let n6 = arena1.new_node("INT".to_string(), "99".to_string(), None, None, None, None);
         // Create action list.
-        let mut actions1: EditScript<&str> = EditScript::new();
+        let mut actions1: EditScript<String> = EditScript::new();
         assert!(actions1.is_empty());
         let del1 = Delete::new(NodeId::new(3)); // INT 3
         let del2 = Delete::new(NodeId::new(4)); // INT 4
@@ -869,7 +869,7 @@ mod test {
         assert_eq!(ins2, ins2);
         assert_ne!(ins1, ins2);
         let mov1 = Move::new(NodeId::new(6), NodeId::new(2), 0); // Swap "INT 100" and "INT 99".
-        let upd1 = Update::new(NodeId::new(0), "Expr", String::from("*"));
+        let upd1 = Update::new(NodeId::new(0), "Expr".to_string(), "*".to_string());
         actions1.push(del1);
         actions1.push(del2);
         actions1.push(ins1);
@@ -880,8 +880,8 @@ mod test {
         assert_eq!(6, actions1.size());
         // Second edit script.
         let mut arena2 = create_mult_arena();
-        let n7 = arena2.new_node("INT", String::from("2"), None, None, None, None);
-        let mut actions2: EditScript<&str> = EditScript::new();
+        let n7 = arena2.new_node("INT".to_string(), "2".to_string(), None, None, None, None);
+        let mut actions2: EditScript<String> = EditScript::new();
         assert!(actions2.is_empty());
         let del3 = Delete { node: NodeId::new(4), }; // Remove "4".
         let ins3 = Insert { node: n7,
@@ -889,8 +889,8 @@ mod test {
                             nth_child: 0, };
         let upd2 = Update { // Change "+" to "*".
                             node: NodeId::new(0),
-                            ty: "Expr",
-                            label: String::from("*"), };
+                            ty: "Expr".to_string(),
+                            label: "*".to_string(), };
         actions2.push(del3);
         actions2.push(ins3);
         actions2.push(upd2);

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -887,6 +887,7 @@ impl<'a, T: Clone, U: PartialEq + Copy> Iterator for PreOrderTraversal<'a, T, U>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_common::create_mult_arena;
 
     #[test]
     fn from_trait_node_ids() {
@@ -928,23 +929,9 @@ mod tests {
                    coerced_to.next_sibling());
     }
 
-    fn create_arena() -> Arena<&'static str, FromNodeId> {
-        let mut arena = Arena::<&str, FromNodeId>::new();
-        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
-        let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
-        n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("Expr", String::from("*"), None, None, None, None);
-        n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node("INT", String::from("3"), None, None, None, None);
-        n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node("INT", String::from("4"), None, None, None, None);
-        n4.make_child_of(n2, &mut arena).unwrap();
-        arena
-    }
-
     #[test]
     fn from_trait_arenas() {
-        let from_arena = create_arena();
+        let from_arena = create_mult_arena();
         let coerced_to_arena = Arena::<&str, ToNodeId>::from(from_arena.clone());
         let coerced_from_arena = Arena::<&str, FromNodeId>::from(coerced_to_arena.clone());
         let format = "\"Expr\" +
@@ -1075,7 +1062,7 @@ mod tests {
 
     #[test]
     fn make_child_of_1() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let root = NodeId::new(0);
         let n1 = NodeId::new(1);
         let n2 = NodeId::new(2);
@@ -1293,7 +1280,7 @@ mod tests {
 
     #[test]
     fn get_edges_3() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let edges: Vec<EdgeId<FromNodeId>> = vec![(NodeId::new(0), NodeId::new(1)),
                                                   (NodeId::new(0), NodeId::new(2)),
                                                   (NodeId::new(2), NodeId::new(3)),
@@ -1303,7 +1290,7 @@ mod tests {
 
     #[test]
     fn detach_1() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let root = NodeId::new(0);
         let first_format = "\"Expr\" +
   \"INT\" 1
@@ -1319,7 +1306,7 @@ mod tests {
 
     #[test]
     fn detach_2() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let n2 = NodeId::new(2);
         let first_format = "\"Expr\" +
   \"INT\" 1
@@ -1337,7 +1324,7 @@ mod tests {
 
     #[test]
     fn children_iterator() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let root = NodeId::new(0);
         let n2 = NodeId::new(2);
         // Children of root.
@@ -1364,7 +1351,7 @@ mod tests {
 
     #[test]
     fn children_iterator_with_add_delete() {
-        let mut arena = create_arena();
+        let mut arena = create_mult_arena();
         let n2 = NodeId::new(2);
         // Children of n2.
         let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 3,
@@ -1422,7 +1409,7 @@ mod tests {
 
     #[test]
     fn reverse_children_iterator() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let root = NodeId::new(0);
         let n2 = NodeId::new(2);
         // Children of root.
@@ -1449,7 +1436,7 @@ mod tests {
 
     #[test]
     fn breadth_first_traversal() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         // Descendants  of root.
         let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId::new(0),
                                                       NodeId::new(1),
@@ -1475,7 +1462,7 @@ mod tests {
 
     #[test]
     fn post_order_traversal() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         // Descendants  of root.
         let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId::new(1),
                                                       NodeId::new(3),
@@ -1501,7 +1488,7 @@ mod tests {
 
     #[test]
     fn pre_order_traversal() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         // Descendants  of root.
         let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId::new(0),
                                                       NodeId::new(1),
@@ -1527,7 +1514,7 @@ mod tests {
 
     #[test]
     fn descendants() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         // Descendants  of root.
         let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId::new(1),
                                                       NodeId::new(2),
@@ -1586,7 +1573,7 @@ mod tests {
 
     #[test]
     fn height() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -1603,7 +1590,7 @@ mod tests {
 
     #[test]
     fn size_on_nodeid() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let format1 = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -1620,7 +1607,7 @@ mod tests {
 
     #[test]
     fn get_child_position() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         assert_eq!(None, NodeId::new(0).get_child_position(&arena));
         assert_eq!(Some(0), NodeId::new(1).get_child_position(&arena));
         assert_eq!(Some(1), NodeId::new(2).get_child_position(&arena));

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -57,7 +57,7 @@ pub enum ArenaError {
     /// Two node ids were unexpectedly identical.
     NodeIdsAreIdentical,
     /// Node has too many children.
-    NodeHasTooManyChildren,
+    NodeHasTooManyChildren
 }
 
 /// Result type returned by AST operations.
@@ -77,7 +77,7 @@ pub enum FromOrToNodeId {
     /// Id for a `from` node.
     FromNodeId(NodeId<FromNodeId>),
     /// Id for a `to` node.
-    ToNodeId(NodeId<ToNodeId>),
+    ToNodeId(NodeId<ToNodeId>)
 }
 
 /// A node identifier used for indexing nodes within a particular `Arena`.
@@ -87,7 +87,7 @@ pub enum FromOrToNodeId {
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd)]
 pub struct NodeId<T: PartialEq + Copy> {
     index: usize,
-    phantom: PhantomData<T>,
+    phantom: PhantomData<T>
 }
 
 impl<T: PartialEq + Copy> fmt::Display for NodeId<T> {
@@ -107,13 +107,13 @@ pub type EdgeId<T> = (NodeId<T>, NodeId<T>);
 #[derive(Clone)]
 pub struct Arena<T: Clone, U: PartialEq + Copy> {
     nodes: Vec<Node<T, U>>,
-    root: Option<NodeId<U>>,
+    root: Option<NodeId<U>>
 }
 
 impl<T: Clone, U: PartialEq + Copy> Default for Arena<T, U> {
     fn default() -> Arena<T, U> {
         Arena { nodes: Vec::new(),
-                root: None, }
+                root: None }
     }
 }
 
@@ -140,7 +140,7 @@ impl<T: Clone + PartialEq> From<Arena<T, ToNodeId>> for Arena<T, FromNodeId> {
                            .map(|node| Node::<T, FromNodeId>::from(node))
                            .collect();
         Arena { nodes: coerced,
-                root: arena.root().map(|id| NodeId::<FromNodeId>::from(id)), }
+                root: arena.root().map(|id| NodeId::<FromNodeId>::from(id)) }
     }
 }
 
@@ -153,7 +153,7 @@ impl<T: Clone + PartialEq> From<Arena<T, FromNodeId>> for Arena<T, ToNodeId> {
                            .map(|node| Node::<T, ToNodeId>::from(node))
                            .collect();
         Arena { nodes: coerced,
-                root: arena.root().map(|id| NodeId::<ToNodeId>::from(id)), }
+                root: arena.root().map(|id| NodeId::<ToNodeId>::from(id)) }
     }
 }
 
@@ -274,7 +274,7 @@ impl<T: Clone + PartialEq, U: PartialEq + Copy> Arena<T, U> {
             let node = &self.nodes[index];
             match node.parent {
                 None => (),
-                Some(par) => edges.push((par, NodeId::<U>::new(index))),
+                Some(par) => edges.push((par, NodeId::<U>::new(index)))
             }
         }
         edges
@@ -309,7 +309,7 @@ impl<T: fmt::Debug + Clone, U: PartialEq + Copy> fmt::Debug for Arena<T, U> {
                     }
                     match self.nodes[current_child.index].previous_sibling {
                         None => break,
-                        Some(id) => current_child = id,
+                        Some(id) => current_child = id
                     };
                 }
             }
@@ -359,7 +359,7 @@ pub struct Node<T: Clone, U: PartialEq + Copy> {
     /// The length of the token this node represents in the original file.
     ///
     /// `None` if this node represents some non-terminal node in the grammar.
-    pub token_len: Option<usize>,
+    pub token_len: Option<usize>
 }
 
 #[cfg(test)]
@@ -381,7 +381,7 @@ impl<T: Clone> From<Node<T, ToNodeId>> for Node<T, FromNodeId> {
                                 line_no: node.line_no,
                                 char_no: node.char_no,
                                 token_len: node.token_len,
-                                hash: node.hash, }
+                                hash: node.hash }
     }
 }
 
@@ -404,7 +404,7 @@ impl<T: Clone> From<Node<T, FromNodeId>> for Node<T, ToNodeId> {
                               line_no: node.line_no,
                               char_no: node.char_no,
                               token_len: node.token_len,
-                              hash: node.hash, }
+                              hash: node.hash }
     }
 }
 
@@ -429,7 +429,7 @@ impl<T: Clone, U: PartialEq + Copy> Node<T, U> {
                line_no,
                char_no,
                token_len,
-               hash: None, }
+               hash: None }
     }
 
     /// Return the Id of the parent node, if there is one.
@@ -493,7 +493,7 @@ impl<U: PartialEq + Copy> NodeId<U> {
     /// Create a new NodeId with a given index.
     pub fn new(index: usize) -> NodeId<U> {
         NodeId { index,
-                 phantom: PhantomData, }
+                 phantom: PhantomData }
     }
 
     /// Return the index of this Node Id.
@@ -744,13 +744,13 @@ impl<U: PartialEq + Copy> NodeId<U> {
     /// Return an iterator of references to this node’s children.
     pub fn children<T: Clone>(self, arena: &Arena<T, U>) -> Children<T, U> {
         Children { arena,
-                   node: arena[self].first_child, }
+                   node: arena[self].first_child }
     }
 
     /// Return an iterator of references to this node’s children, in reverse order.
     pub fn reverse_children<T: Clone>(self, arena: &Arena<T, U>) -> ReverseChildren<T, U> {
         ReverseChildren { arena,
-                          node: arena[self].last_child, }
+                          node: arena[self].last_child }
     }
 
     /// Return a breadth-first iterator of references to this node's descendants.
@@ -768,7 +768,7 @@ impl<U: PartialEq + Copy> NodeId<U> {
         stack1.push_front(self);
         PostOrderTraversal { arena,
                              stack1,
-                             stack2: VecDeque::new(), }
+                             stack2: VecDeque::new() }
     }
 
     /// Return a pre-order iterator of references to this node's descendants.
@@ -808,14 +808,14 @@ macro_rules! impl_node_iterator {
 /// An iterator of references to the children of a given node.
 pub struct Children<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
     arena: &'a Arena<T, U>,
-    node: Option<NodeId<U>>,
+    node: Option<NodeId<U>>
 }
 impl_node_iterator!(Children, |node: &Node<T, U>| node.next_sibling);
 
 /// An iterator of references to the children of a given node.
 pub struct ReverseChildren<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
     arena: &'a Arena<T, U>,
-    node: Option<NodeId<U>>,
+    node: Option<NodeId<U>>
 }
 impl_node_iterator!(ReverseChildren, |node: &Node<T, U>| {
     node.previous_sibling
@@ -824,7 +824,7 @@ impl_node_iterator!(ReverseChildren, |node: &Node<T, U>| {
 /// A breadth-first iterator of references to the descendants of a given node.
 pub struct BreadthFirstTraversal<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
     arena: &'a Arena<T, U>,
-    queue: VecDeque<NodeId<U>>,
+    queue: VecDeque<NodeId<U>>
 }
 
 impl<'a, T: Clone, U: PartialEq + Copy> Iterator for BreadthFirstTraversal<'a, T, U> {
@@ -837,7 +837,7 @@ impl<'a, T: Clone, U: PartialEq + Copy> Iterator for BreadthFirstTraversal<'a, T
                 }
                 Some(node)
             }
-            None => None,
+            None => None
         }
     }
 }
@@ -846,7 +846,7 @@ impl<'a, T: Clone, U: PartialEq + Copy> Iterator for BreadthFirstTraversal<'a, T
 pub struct PostOrderTraversal<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
     arena: &'a Arena<T, U>,
     stack1: VecDeque<NodeId<U>>,
-    stack2: VecDeque<NodeId<U>>,
+    stack2: VecDeque<NodeId<U>>
 }
 
 impl<'a, T: Clone, U: PartialEq + Copy> Iterator for PostOrderTraversal<'a, T, U> {
@@ -867,7 +867,7 @@ impl<'a, T: Clone, U: PartialEq + Copy> Iterator for PostOrderTraversal<'a, T, U
 /// A pre-order iterator of references to the descendants of a given node.
 pub struct PreOrderTraversal<'a, T: Clone + 'a, U: PartialEq + Copy + 'a> {
     arena: &'a Arena<T, U>,
-    stack: VecDeque<NodeId<U>>,
+    stack: VecDeque<NodeId<U>>
 }
 
 impl<'a, T: Clone, U: PartialEq + Copy> Iterator for PreOrderTraversal<'a, T, U> {
@@ -1329,9 +1329,9 @@ mod tests {
         let n2 = NodeId::new(2);
         // Children of root.
         let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 1,
-                                                               phantom: PhantomData, },
+                                                               phantom: PhantomData },
                                                       NodeId { index: 2,
-                                                               phantom: PhantomData, }];
+                                                               phantom: PhantomData }];
         let root_child_ids = root.children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected1.len(), root_child_ids.len());
         for index in 0..expected1.len() {
@@ -1339,9 +1339,9 @@ mod tests {
         }
         // Children of n2.
         let expected2: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 3,
-                                                               phantom: PhantomData, },
+                                                               phantom: PhantomData },
                                                       NodeId { index: 4,
-                                                               phantom: PhantomData, }];
+                                                               phantom: PhantomData }];
         let n2_child_ids = n2.children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected2.len(), n2_child_ids.len());
         for index in 0..expected2.len() {
@@ -1355,9 +1355,9 @@ mod tests {
         let n2 = NodeId::new(2);
         // Children of n2.
         let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 3,
-                                                               phantom: PhantomData, },
+                                                               phantom: PhantomData },
                                                       NodeId { index: 4,
-                                                               phantom: PhantomData, }];
+                                                               phantom: PhantomData }];
         let n2_child_ids = n2.children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected1.len(), n2_child_ids.len());
         for index in 0..expected1.len() {
@@ -1372,7 +1372,7 @@ mod tests {
         let n5 = arena.new_node("INT".to_string(), "100".to_string(), None, None, None, None);
         n5.make_child_of(n2, &mut arena).unwrap();
         let expected2: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 3,
-                                                               phantom: PhantomData, },
+                                                               phantom: PhantomData },
                                                       n5];
         let n2_child_ids_add = n2.children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected2.len(), n2_child_ids_add.len());
@@ -1383,7 +1383,7 @@ mod tests {
         let n6 = arena.new_node("INT".to_string(), "-99".to_string(), None, None, None, None);
         n6.make_nth_child_of(n2, 1, &mut arena).unwrap();
         let expected3: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 3,
-                                                               phantom: PhantomData, },
+                                                               phantom: PhantomData },
                                                       n6,
                                                       n5];
         let n2_child_ids_nth = n2.children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
@@ -1396,7 +1396,7 @@ mod tests {
         n7.make_nth_child_of(n2, 0, &mut arena).unwrap();
         let expected4: Vec<NodeId<FromNodeId>> = vec![n7,
                                                       NodeId { index: 3,
-                                                               phantom: PhantomData, },
+                                                               phantom: PhantomData },
                                                       n6,
                                                       n5];
         let n2_child_ids_0th = n2.children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
@@ -1414,9 +1414,9 @@ mod tests {
         let n2 = NodeId::new(2);
         // Children of root.
         let expected1: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 2,
-                                                               phantom: PhantomData, },
+                                                               phantom: PhantomData },
                                                       NodeId { index: 1,
-                                                               phantom: PhantomData, }];
+                                                               phantom: PhantomData }];
         let root_child_ids = root.reverse_children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected1.len(), root_child_ids.len());
         for index in 0..expected1.len() {
@@ -1424,9 +1424,9 @@ mod tests {
         }
         // Children of n2.
         let expected2: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 4,
-                                                               phantom: PhantomData, },
+                                                               phantom: PhantomData },
                                                       NodeId { index: 3,
-                                                               phantom: PhantomData, }];
+                                                               phantom: PhantomData }];
         let n2_child_ids = n2.reverse_children(&arena).collect::<Vec<NodeId<FromNodeId>>>();
         assert_eq!(expected2.len(), n2_child_ids.len());
         for index in 0..expected2.len() {
@@ -1542,7 +1542,7 @@ mod tests {
         let n1 = arena.new_node("1", String::from("INT"), None, None, None, None);
         assert!(arena.contains(n1));
         assert!(!arena.contains(NodeId { index: 1,
-                                         phantom: PhantomData, }));
+                                         phantom: PhantomData }));
     }
 
     #[test]

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -932,8 +932,8 @@ mod tests {
     #[test]
     fn from_trait_arenas() {
         let from_arena = create_mult_arena();
-        let coerced_to_arena = Arena::<&str, ToNodeId>::from(from_arena.clone());
-        let coerced_from_arena = Arena::<&str, FromNodeId>::from(coerced_to_arena.clone());
+        let coerced_to_arena = Arena::<String, ToNodeId>::from(from_arena.clone());
+        let coerced_from_arena = Arena::<String, FromNodeId>::from(coerced_to_arena.clone());
         let format = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -1369,7 +1369,7 @@ mod tests {
         assert_eq!(1, n2_child_ids_del.len());
         assert_eq!(n2_child_ids[0], NodeId::new(3));
         // Add a new node.
-        let n5 = arena.new_node("INT", String::from("100"), None, None, None, None);
+        let n5 = arena.new_node("INT".to_string(), "100".to_string(), None, None, None, None);
         n5.make_child_of(n2, &mut arena).unwrap();
         let expected2: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 3,
                                                                phantom: PhantomData, },
@@ -1380,7 +1380,7 @@ mod tests {
             assert_eq!(expected2[index], n2_child_ids_add[index]);
         }
         // Add a new node as nth child.
-        let n6 = arena.new_node("INT", String::from("-99"), None, None, None, None);
+        let n6 = arena.new_node("INT".to_string(), "-99".to_string(), None, None, None, None);
         n6.make_nth_child_of(n2, 1, &mut arena).unwrap();
         let expected3: Vec<NodeId<FromNodeId>> = vec![NodeId { index: 3,
                                                                phantom: PhantomData, },
@@ -1392,7 +1392,7 @@ mod tests {
             assert_eq!(expected3[index], n2_child_ids_nth[index]);
         }
         // Add a new node as 0th child.
-        let n7 = arena.new_node("INT", String::from("-1"), None, None, None, None);
+        let n7 = arena.new_node("INT".to_string(), "-1".to_string(), None, None, None, None);
         n7.make_nth_child_of(n2, 0, &mut arena).unwrap();
         let expected4: Vec<NodeId<FromNodeId>> = vec![n7,
                                                       NodeId { index: 3,

--- a/src/lib/chawathe98_matcher.rs
+++ b/src/lib/chawathe98_matcher.rs
@@ -74,7 +74,7 @@ pub enum EdgeType {
     /// Edge corresponds to a NULL operation.
     NULL,
     /// Edge corresponds to a OK operation.
-    OK,
+    OK
 }
 
 /// The initial cost of each edge
@@ -95,7 +95,7 @@ pub struct CostEdge {
     /// Edge corresponds to a NULL cost operation.
     pub null: usize,
     /// Edge corresponds to a OK cost operation.
-    pub ok: usize,
+    pub ok: usize
 }
 
 /// This shows the Cost Edge Struct where the user can define the cost of different edge type.
@@ -118,7 +118,7 @@ impl CostEdge {
                    copy,
                    glue,
                    null,
-                   ok, }
+                   ok }
     }
 }
 
@@ -132,7 +132,7 @@ pub struct Edge {
     /// The value of the edge
     pub value: usize,
     /// The edge type
-    pub edge_type: EdgeType,
+    pub edge_type: EdgeType
 }
 
 impl Edge {
@@ -145,7 +145,7 @@ impl Edge {
         Edge { from_node,
                to_node,
                value,
-               edge_type, }
+               edge_type }
     }
 }
 
@@ -172,7 +172,7 @@ pub struct MappingStoreGraph<T: Clone + Debug> {
     /// Mappings from the destination tree to the source.
     ///
     /// Should contain the same information as `from_map`.
-    pub to: RefCell<NodeAndEdgeType<ToNodeId, FromNodeId>>,
+    pub to: RefCell<NodeAndEdgeType<ToNodeId, FromNodeId>>
 }
 
 impl<T: Clone + Debug + Eq + 'static> MappingStoreGraph<T> {
@@ -188,7 +188,7 @@ impl<T: Clone + Debug + Eq + 'static> MappingStoreGraph<T> {
                             // which is cost the value of 1.
                             all_edge_cost: CostEdge::new(1, 1, 1, 1, 1, 1, 1, 1),
                             from: RefCell::new(HashMap::new()),
-                            to: RefCell::new(HashMap::new()), }
+                            to: RefCell::new(HashMap::new()) }
     }
 
     /// Implementation of the update of the cost edge.

--- a/src/lib/emitters.rs
+++ b/src/lib/emitters.rs
@@ -61,7 +61,7 @@ pub enum EmitterError {
     /// Could not read from a file.
     CouldNotReadFile,
     /// Could not open an existing file.
-    CouldNotOpenFile,
+    CouldNotOpenFile
 }
 
 /// Result returned by emitters.
@@ -251,11 +251,8 @@ fn escape_string(label: &str) -> String {
 }
 
 /// Write out a graphviz file (in dot format) to `filepath`.
-pub fn write_dotfile_to_disk<T: RenderDotfile>(filepath: &str,
-                                               graph: &T)
-                                               -> EmitterResult {
-    let mut stream =
-        File::create(&filepath).map_err(|_| EmitterError::CouldNotCreateFile)?;
+pub fn write_dotfile_to_disk<T: RenderDotfile>(filepath: &str, graph: &T) -> EmitterResult {
+    let mut stream = File::create(&filepath).map_err(|_| EmitterError::CouldNotCreateFile)?;
     graph.render_dotfile(&mut stream)
          .map_err(|_| EmitterError::CouldNotWriteToFile)
 }
@@ -400,7 +397,7 @@ impl RenderDotfile for MappingStore<String> {
                 MappingType::ANCHOR => "[style=dashed, color=blue, ",
                 MappingType::CONTAINER => "[style=dashed, color=red, ",
                 MappingType::RECOVERY => "[style=dotted, color=green, ",
-                MappingType::EDIT => "[style=dotted, color=indigo, ",
+                MappingType::EDIT => "[style=dotted, color=indigo, "
             };
             line = format!("\t{{ rank=same FROM{} -> TO{}{}{}]; }}\n",
                            from.id(),
@@ -508,7 +505,7 @@ impl RenderDotfile for MappingStoreGraph<String> {
                 EdgeType::COPY => "[style = dotted, color=purple, ",
                 EdgeType::GLUE => "[style = dotted, color=orange, ",
                 EdgeType::NULL => "[style = dotted, color=grey, ",
-                EdgeType::OK => "[style = dotted, color=brown, ",
+                EdgeType::OK => "[style = dotted, color=brown, "
             };
             line = format!("\t FROM{} -> TO{}{}{}]; \n",
                            edge.from_node.id(),

--- a/src/lib/fingerprint.rs
+++ b/src/lib/fingerprint.rs
@@ -123,13 +123,13 @@ pub trait HashGenerator<T: Clone + Debug + Eq + Hash + ToString> {
 
 /// The md5 rolling hash generator from GumTree.
 pub struct Md5HashGenerator {
-    generator: Md5,
+    generator: Md5
 }
 
 impl Md5HashGenerator {
     /// Create a new md5 rolling hash generator.
     pub fn new() -> Md5HashGenerator {
-        Md5HashGenerator { generator: Md5::new(), }
+        Md5HashGenerator { generator: Md5::new() }
     }
 }
 

--- a/src/lib/gt_matcher.rs
+++ b/src/lib/gt_matcher.rs
@@ -52,14 +52,14 @@ pub struct GumTreeConfig {
     pub min_dice: f32,
 
     /// Only consider sub-trees for matching if they have a height `< MIN_HEIGHT`.
-    pub min_height: u16,
+    pub min_height: u16
 }
 
 impl Default for GumTreeConfig {
     fn default() -> GumTreeConfig {
         GumTreeConfig { max_size: 100,
                         min_dice: 0.3,
-                        min_height: 2, }
+                        min_height: 2 }
     }
 }
 

--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -51,7 +51,7 @@ use ast::{Arena, NodeId};
 #[derive(Clone, Eq, PartialEq)]
 struct PriorityNodeId<T: PartialEq + Copy> {
     index: NodeId<T>,
-    height: u32,
+    height: u32
 }
 
 impl<T: PartialEq + Copy> PriorityNodeId<T> {
@@ -83,7 +83,7 @@ impl<T: Eq + PartialEq + Copy> PartialOrd for PriorityNodeId<T> {
 /// A queue of `NodeId`s sorted on the height of their respective nodes.
 #[derive(Clone, Eq, PartialEq)]
 pub struct HeightQueue<T: PartialEq + Copy> {
-    queue: Vec<PriorityNodeId<T>>, // Use Vec so we can call `sort()`.
+    queue: Vec<PriorityNodeId<T>> // Use Vec so we can call `sort()`.
 }
 
 impl<T: PartialEq + Copy> Default for HeightQueue<T> {

--- a/src/lib/hqueue.rs
+++ b/src/lib/hqueue.rs
@@ -179,27 +179,7 @@ mod tests {
     use super::*;
     use ast::FromNodeId;
     use test::Bencher;
-
-    fn create_arena() -> Arena<&'static str, FromNodeId> {
-        let mut arena = Arena::new();
-        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
-        let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
-        n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("Expr", String::from("*"), None, None, None, None);
-        n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node("INT", String::from("3"), None, None, None, None);
-        n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node("INT", String::from("4"), None, None, None, None);
-        n4.make_child_of(n2, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
-";
-        assert_eq!(format1, format!("{:?}", arena));
-        arena
-    }
+    use test_common::create_mult_arena;
 
     // Assert that `queue` is in sorted order and has the same size `arena`.
     fn assert_sorted<T: Clone + PartialEq>(queue: &HeightQueue<FromNodeId>,
@@ -229,7 +209,7 @@ mod tests {
 
     #[test]
     fn clear() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let mut queue = arena.get_priority_queue();
         assert!(!queue.is_empty());
         queue.clear();
@@ -253,7 +233,7 @@ mod tests {
 
     #[test]
     fn fmt_debug() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let queue = arena.get_priority_queue();
         let s = format!("{:?}", queue);
         // Three leaves in this arena can be placed in the queue in any order,
@@ -272,7 +252,7 @@ mod tests {
 
     #[test]
     fn open() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let mut queue = HeightQueue::<FromNodeId>::new();
         queue.open(&NodeId::new(0), &arena);
         let expected1 = vec![NodeId::new(2)]; // Expr *
@@ -283,7 +263,7 @@ mod tests {
 
     #[test]
     fn peek_max() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let queue = arena.get_priority_queue();
         let height = queue.peek_max().unwrap();
         assert_eq!(NodeId::new(0).height(&arena), height);
@@ -291,7 +271,7 @@ mod tests {
 
     #[test]
     fn pop() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let mut queue = arena.get_priority_queue();
         assert_eq!(vec![NodeId::new(0)], queue.pop());
         assert_eq!(vec![NodeId::new(2)], queue.pop());
@@ -307,14 +287,14 @@ mod tests {
 
     #[test]
     fn push() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let queue = arena.get_priority_queue();
         assert_sorted(&queue, &arena);
     }
 
     #[test]
     fn push_identical_nodes() {
-        let arena = create_arena();
+        let arena = create_mult_arena();
         let mut queue = HeightQueue::new();
         queue.push(NodeId::new(0), &arena);
         let formatted = format!("{:?}", queue);

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -261,42 +261,7 @@ pub fn has_same_type<T: Clone + Debug + Eq>(n1: &NodeId<FromNodeId>,
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn create_mult_arena() -> Arena<&'static str, FromNodeId> {
-        let mut arena = Arena::new();
-        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
-        let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
-        n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("Expr", String::from("*"), None, None, None, None);
-        n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node("INT", String::from("3"), None, None, None, None);
-        n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node("INT", String::from("4"), None, None, None, None);
-        n4.make_child_of(n2, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
-";
-        assert_eq!(format1, format!("{:?}", arena));
-        arena
-    }
-
-    fn create_plus_arena() -> Arena<&'static str, FromNodeId> {
-        let mut arena = Arena::new();
-        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
-        let n1 = arena.new_node("INT", String::from("3"), None, None, None, None);
-        n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("INT", String::from("4"), None, None, None, None);
-        n2.make_child_of(root, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 3
-  \"INT\" 4
-";
-        assert_eq!(format1, format!("{:?}", arena));
-        arena
-    }
+    use test_common::{create_mult_arena, create_plus_arena};
 
     #[test]
     fn is_isomorphic() {

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -267,11 +267,11 @@ mod tests {
     fn is_isomorphic() {
         let mult = create_mult_arena();
         let plus = create_plus_arena();
-        let store_p = MappingStore::new(plus.clone(),
-                                        Arena::<&'static str, ToNodeId>::from(plus.clone()));
-        let store_m = MappingStore::new(mult.clone(),
-                                        Arena::<&'static str, ToNodeId>::from(mult.clone()));
-        let store = MappingStore::new(plus, Arena::<&'static str, ToNodeId>::from(mult));
+        let store_p =
+            MappingStore::new(plus.clone(), Arena::<String, ToNodeId>::from(plus.clone()));
+        let store_m =
+            MappingStore::new(mult.clone(), Arena::<String, ToNodeId>::from(mult.clone()));
+        let store = MappingStore::new(plus, Arena::<String, ToNodeId>::from(mult));
         // Isomorphic.
         assert!(store_p.is_isomorphic(NodeId::new(0), NodeId::new(0)));
         assert!(store_p.is_isomorphic(NodeId::new(1), NodeId::new(1)));
@@ -294,11 +294,11 @@ mod tests {
     fn is_isomorphic_hash() {
         let mult = create_mult_arena();
         let plus = create_plus_arena();
-        let store_p = MappingStore::new(plus.clone(),
-                                        Arena::<&'static str, ToNodeId>::from(plus.clone()));
-        let store_m = MappingStore::new(mult.clone(),
-                                        Arena::<&'static str, ToNodeId>::from(mult.clone()));
-        let store = MappingStore::new(plus, Arena::<&'static str, ToNodeId>::from(mult));
+        let store_p =
+            MappingStore::new(plus.clone(), Arena::<String, ToNodeId>::from(plus.clone()));
+        let store_m =
+            MappingStore::new(mult.clone(), Arena::<String, ToNodeId>::from(mult.clone()));
+        let store = MappingStore::new(plus, Arena::<String, ToNodeId>::from(mult));
         // Isomorphic.
         assert!(store_p.is_isomorphic(NodeId::new(0), NodeId::new(0)));
         assert!(store_p.is_isomorphic(NodeId::new(1), NodeId::new(1)));
@@ -321,7 +321,7 @@ mod tests {
     fn is_mapping_allowed() {
         let mult = create_mult_arena();
         let plus = create_plus_arena();
-        let store = MappingStore::new(plus, Arena::<&'static str, ToNodeId>::from(mult));
+        let store = MappingStore::new(plus, Arena::<String, ToNodeId>::from(mult));
         assert!(store.is_mapping_allowed(&NodeId::new(0), &NodeId::new(2)));
         assert!(store.is_mapping_allowed(&NodeId::new(1), &NodeId::new(3)));
         assert!(store.is_mapping_allowed(&NodeId::new(2), &NodeId::new(4)));
@@ -343,7 +343,7 @@ mod tests {
     fn is_mapped() {
         let mult = create_mult_arena();
         let plus = create_plus_arena();
-        let store = MappingStore::new(plus, Arena::<&'static str, ToNodeId>::from(mult));
+        let store = MappingStore::new(plus, Arena::<String, ToNodeId>::from(mult));
         store.push(NodeId::new(0), NodeId::new(0), &MappingType::ANCHOR);
         store.push(NodeId::new(2), NodeId::new(4), &MappingType::ANCHOR);
         assert!(store.is_mapped(&NodeId::new(0), &NodeId::new(0)));
@@ -368,7 +368,7 @@ mod tests {
         let plus = create_plus_arena();
         let mult = create_mult_arena();
         let matcher = MyersConfig::new();
-        let store = matcher.match_trees(plus, Arena::<&'static str, ToNodeId>::from(mult));
+        let store = matcher.match_trees(plus, Arena::<String, ToNodeId>::from(mult));
         let expected_str = vec!["\"matches\": [",
                                 "{\n\"src\": 1,\n\"dest\": 3\n}",
                                 "{\n\"src\": 0,\n\"dest\": 0\n}",

--- a/src/lib/matchers.rs
+++ b/src/lib/matchers.rs
@@ -62,7 +62,7 @@ pub enum MappingType {
     /// A mapping added by the algorithm that generates the edit script.
     ///
     /// See Chawathe et al. (1996).
-    EDIT,
+    EDIT
 }
 
 impl Default for MappingType {
@@ -86,7 +86,7 @@ pub struct MappingStore<T: Clone + Debug + ToString> {
     /// Source arena (treat as mutable).
     pub from_arena: RefCell<Arena<T, FromNodeId>>,
     /// Destination arena (treat as immutable).
-    pub to_arena: RefCell<Arena<T, ToNodeId>>,
+    pub to_arena: RefCell<Arena<T, ToNodeId>>
 }
 
 impl<T: Clone + Debug + ToString> RenderJson for MappingStore<T> {
@@ -114,7 +114,7 @@ impl<T: Clone + Debug + Eq + ToString + 'static> MappingStore<T> {
         MappingStore { from: RefCell::new(HashMap::new()),
                        to: RefCell::new(HashMap::new()),
                        from_arena: RefCell::new(base),
-                       to_arena: RefCell::new(diff), }
+                       to_arena: RefCell::new(diff) }
     }
 
     /// Push a new mapping into the store.

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -139,7 +139,7 @@ pub mod test_common {
         #[serde(deserialize_with = "to_string")]
         ty: String,
         #[serde(rename = "Tree", default)]
-        children: Vec<Tree>,
+        children: Vec<Tree>
     }
 
     /// Load an AST from an XML string.
@@ -233,7 +233,7 @@ pub mod test_common {
         let xml = "<Tree ty=\"0\" label=\"a\"></Tree>";
         let expected = Tree { ty: String::from("0"),
                               label: String::from("a"),
-                              children: vec![], };
+                              children: vec![] };
         assert_eq!(expected, load_xml_tree(xml));
     }
 
@@ -247,7 +247,7 @@ pub mod test_common {
                               label: "a".to_string(),
                               children: vec![Tree { ty: "0".to_string(),
                                                     label: "b".to_string(),
-                                                    children: vec![], }], };
+                                                    children: vec![] }] };
         assert_eq!(expected, load_xml_tree(xml));
     }
 
@@ -267,18 +267,18 @@ pub mod test_common {
                    label: "a".to_string(),
                    children: vec![Tree { ty: "0".to_string(),
                                          label: "b".to_string(),
-                                         children: vec![], },
+                                         children: vec![] },
                                   Tree { ty: "0".to_string(),
                                          label: "c".to_string(),
                                          children: vec![Tree { ty: "0".to_string(),
                                                                label: "d".to_string(),
-                                                               children: vec![], },
+                                                               children: vec![] },
                                                         Tree { ty: "0".to_string(),
                                                                label: "e".to_string(),
-                                                               children: vec![], },
+                                                               children: vec![] },
                                                         Tree { ty: "0".to_string(),
                                                                label: "f".to_string(),
-                                                               children: vec![], }], }], };
+                                                               children: vec![] }] }] };
         assert_eq!(expected, load_xml_tree(xml));
     }
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -187,17 +187,16 @@ pub mod test_common {
     ///     let mult = create_mult_arena();
     ///     ... Arena::<&'static str, ToNodeId>::from(mult) ...
     /// ```
-    pub fn create_mult_arena() -> Arena<&'static str, FromNodeId> {
-        let mut arena = Arena::new();
-        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
-        let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
-        n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("Expr", String::from("*"), None, None, None, None);
-        n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node("INT", String::from("3"), None, None, None, None);
-        n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node("INT", String::from("4"), None, None, None, None);
-        n4.make_child_of(n2, &mut arena).unwrap();
+    pub fn create_mult_arena() -> Arena<String, FromNodeId> {
+        let xml = "<Tree ty=\"Expr\" label=\"+\">
+        <Tree ty=\"INT\" label=\"1\"/>
+        <Tree ty=\"Expr\" label=\"*\">
+            <Tree ty=\"INT\" label=\"3\"/>
+            <Tree ty=\"INT\" label=\"4\"/>
+        </Tree>
+    </Tree>
+    ";
+        let arena = load_xml_ast(xml);
         let expected_format = "\"Expr\" +
   \"INT\" 1
   \"Expr\" *
@@ -214,13 +213,13 @@ pub mod test_common {
     ///     let plus = create_plus_arena();
     ///     ... Arena::<&'static str, ToNodeId>::from(plus) ...
     /// ```
-    pub fn create_plus_arena() -> Arena<&'static str, FromNodeId> {
-        let mut arena = Arena::new();
-        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
-        let n1 = arena.new_node("INT", String::from("3"), None, None, None, None);
-        n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("INT", String::from("4"), None, None, None, None);
-        n2.make_child_of(root, &mut arena).unwrap();
+    pub fn create_plus_arena() -> Arena<String, FromNodeId> {
+        let xml = "<Tree ty=\"Expr\" label=\"+\">
+        <Tree ty=\"INT\" label=\"3\"/>
+        <Tree ty=\"INT\" label=\"4\"/>
+    </Tree>
+    ";
+        let arena = load_xml_ast(xml);
         let expected_format = "\"Expr\" +
   \"INT\" 3
   \"INT\" 4

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -111,3 +111,56 @@ pub mod chawathe98_matcher;
 
 /// Fingerprinting algorithms for tree isomorphism tests.
 pub mod fingerprint;
+
+#[cfg(test)]
+pub mod test_common {
+    use ast::{Arena, FromNodeId};
+
+    /// Create an arena of type `Arena<&'static str, FromNodeId>` for testing.
+    /// To use this as a destination parse tree, use the `From` trait:
+    ///  ```
+    ///     let mult = create_mult_arena();
+    ///     ... Arena::<&'static str, ToNodeId>::from(mult) ...
+    /// ```
+    pub fn create_mult_arena() -> Arena<&'static str, FromNodeId> {
+        let mut arena = Arena::new();
+        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
+        let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
+        n1.make_child_of(root, &mut arena).unwrap();
+        let n2 = arena.new_node("Expr", String::from("*"), None, None, None, None);
+        n2.make_child_of(root, &mut arena).unwrap();
+        let n3 = arena.new_node("INT", String::from("3"), None, None, None, None);
+        n3.make_child_of(n2, &mut arena).unwrap();
+        let n4 = arena.new_node("INT", String::from("4"), None, None, None, None);
+        n4.make_child_of(n2, &mut arena).unwrap();
+        let expected_format = "\"Expr\" +
+  \"INT\" 1
+  \"Expr\" *
+    \"INT\" 3
+    \"INT\" 4
+";
+        assert_eq!(expected_format, format!("{:?}", arena));
+        arena
+    }
+
+    /// Create an arena of type `Arena<&'static str, FromNodeId>` for testing.
+    /// To use this as a destination parse tree, use the `From` trait:
+    ///  ```
+    ///     let plus = create_plus_arena();
+    ///     ... Arena::<&'static str, ToNodeId>::from(plus) ...
+    /// ```
+    pub fn create_plus_arena() -> Arena<&'static str, FromNodeId> {
+        let mut arena = Arena::new();
+        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
+        let n1 = arena.new_node("INT", String::from("3"), None, None, None, None);
+        n1.make_child_of(root, &mut arena).unwrap();
+        let n2 = arena.new_node("INT", String::from("4"), None, None, None, None);
+        n2.make_child_of(root, &mut arena).unwrap();
+        let expected_format = "\"Expr\" +
+  \"INT\" 3
+  \"INT\" 4
+";
+        assert_eq!(expected_format, format!("{:?}", arena));
+        arena
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -50,6 +50,14 @@ extern crate multiset;
 extern crate term;
 extern crate test;
 
+#[cfg(test)]
+extern crate serde;
+#[cfg(test)]
+#[macro_use]
+extern crate serde_derive;
+#[cfg(test)]
+extern crate serde_xml_rs;
+
 /// Actions are operations that transform abstract syntax trees.
 pub mod action;
 
@@ -114,7 +122,64 @@ pub mod fingerprint;
 
 #[cfg(test)]
 pub mod test_common {
-    use ast::{Arena, FromNodeId};
+    use serde::{Deserialize, Deserializer};
+    use serde_xml_rs::deserialize;
+
+    use ast::{Arena, FromNodeId, NodeId};
+
+    fn to_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+        where D: Deserializer<'de>
+    {
+        Ok(Deserialize::deserialize(deserializer)?)
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+    struct Tree {
+        label: String,
+        #[serde(deserialize_with = "to_string")]
+        ty: String,
+        #[serde(rename = "Tree", default)]
+        children: Vec<Tree>,
+    }
+
+    /// Load an AST from an XML string.
+    /// Intended to be used for small trees needed by unit tests.
+    ///
+    /// To use the result as a destination parse tree, use the `From` trait:
+    ///  ```
+    ///     let xmltree = load_xml_tree(...);
+    ///     ... Arena::<&'static str, ToNodeId>::from(xmltree) ...
+    /// ```
+    pub fn load_xml_ast(xml: &str) -> Arena<String, FromNodeId> {
+        tree_to_arena(load_xml_tree(xml))
+    }
+
+    fn load_xml_tree(xml: &str) -> Tree {
+        deserialize(xml.as_bytes()).unwrap()
+    }
+
+    fn tree_to_arena(tree: Tree) -> Arena<String, FromNodeId> {
+        let mut arena = Arena::new();
+        let mut next_root = vec![tree.clone()];
+        let mut root = arena.new_node(tree.ty.clone(), tree.label.clone(), None, None, None, None);
+        let mut next_node: Vec<NodeId<FromNodeId>> = vec![root];
+        while !next_root.is_empty() {
+            let next_tree = next_root.pop().unwrap();
+            root = next_node.pop().unwrap();
+            for child in next_tree.children.clone() {
+                let node = arena.new_node(child.ty.clone(),
+                                          child.label.clone(),
+                                          None,
+                                          None,
+                                          None,
+                                          None);
+                node.make_child_of(root, &mut arena).ok();
+                next_root.push(child);
+                next_node.push(node);
+            }
+        }
+        arena
+    }
 
     /// Create an arena of type `Arena<&'static str, FromNodeId>` for testing.
     /// To use this as a destination parse tree, use the `From` trait:
@@ -162,5 +227,109 @@ pub mod test_common {
 ";
         assert_eq!(expected_format, format!("{:?}", arena));
         arena
+    }
+
+    #[test]
+    fn load_xml0() {
+        let xml = "<Tree ty=\"0\" label=\"a\"></Tree>";
+        let expected = Tree { ty: String::from("0"),
+                              label: String::from("a"),
+                              children: vec![], };
+        assert_eq!(expected, load_xml_tree(xml));
+    }
+
+    #[test]
+    fn load_xml1() {
+        let xml = "<Tree ty=\"0\" label=\"a\">
+        <Tree ty=\"0\" label=\"b\"/></Tree>
+    </Tree>
+    ";
+        let expected = Tree { ty: "0".to_string(),
+                              label: "a".to_string(),
+                              children: vec![Tree { ty: "0".to_string(),
+                                                    label: "b".to_string(),
+                                                    children: vec![], }], };
+        assert_eq!(expected, load_xml_tree(xml));
+    }
+
+    #[test]
+    fn load_xml2() {
+        let xml = "<Tree ty=\"0\" label=\"a\">
+        <Tree ty=\"0\" label=\"b\"/>
+        <Tree ty=\"0\" label=\"c\">
+            <Tree ty=\"0\" label=\"d\"/>
+            <Tree ty=\"0\" label=\"e\"/>
+            <Tree ty=\"0\" label=\"f\"/>
+        </Tree>
+    </Tree>
+    ";
+        let expected =
+            Tree { ty: "0".to_string(),
+                   label: "a".to_string(),
+                   children: vec![Tree { ty: "0".to_string(),
+                                         label: "b".to_string(),
+                                         children: vec![], },
+                                  Tree { ty: "0".to_string(),
+                                         label: "c".to_string(),
+                                         children: vec![Tree { ty: "0".to_string(),
+                                                               label: "d".to_string(),
+                                                               children: vec![], },
+                                                        Tree { ty: "0".to_string(),
+                                                               label: "e".to_string(),
+                                                               children: vec![], },
+                                                        Tree { ty: "0".to_string(),
+                                                               label: "f".to_string(),
+                                                               children: vec![], }], }], };
+        assert_eq!(expected, load_xml_tree(xml));
+    }
+
+    #[test]
+    fn convert_arena0() {
+        let xml = "<Tree ty=\"0\" label=\"a\"></Tree>";
+        let tree = load_xml_tree(xml);
+        let mut arena: Arena<String, FromNodeId> = Arena::new();
+        arena.new_node("0".to_string(), "a".to_string(), None, None, None, None);
+        assert_eq!(format!("{:?}", arena), format!("{:?}", tree_to_arena(tree)));
+    }
+
+    #[test]
+    fn convert_arena1() {
+        let xml = "<Tree ty=\"0\" label=\"a\">
+        <Tree ty=\"0\" label=\"b\"/></Tree>
+    </Tree>
+    ";
+        let tree = load_xml_tree(xml);
+        let mut arena: Arena<String, FromNodeId> = Arena::new();
+        let root = arena.new_node("0".to_string(), "a".to_string(), None, None, None, None);
+        let b = arena.new_node("0".to_string(), "b".to_string(), None, None, None, None);
+        b.make_child_of(root, &mut arena).unwrap();
+        assert_eq!(format!("{:?}", arena), format!("{:?}", tree_to_arena(tree)));
+    }
+
+    #[test]
+    fn convert_arena2() {
+        let xml = "<Tree ty=\"0\" label=\"a\">
+        <Tree ty=\"0\" label=\"b\"/>
+        <Tree ty=\"0\" label=\"c\">
+            <Tree ty=\"0\" label=\"d\"/>
+            <Tree ty=\"0\" label=\"e\"/>
+            <Tree ty=\"0\" label=\"f\"/>
+        </Tree>
+    </Tree>
+    ";
+        let tree = load_xml_tree(xml);
+        let mut arena: Arena<String, FromNodeId> = Arena::new();
+        let a = arena.new_node("0".to_string(), "a".to_string(), None, None, None, None);
+        let b = arena.new_node("0".to_string(), "b".to_string(), None, None, None, None);
+        b.make_child_of(a, &mut arena).unwrap();
+        let c = arena.new_node("0".to_string(), "c".to_string(), None, None, None, None);
+        c.make_child_of(a, &mut arena).unwrap();
+        let d = arena.new_node("0".to_string(), "d".to_string(), None, None, None, None);
+        d.make_child_of(c, &mut arena).unwrap();
+        let e = arena.new_node("0".to_string(), "e".to_string(), None, None, None, None);
+        e.make_child_of(c, &mut arena).unwrap();
+        let f = arena.new_node("0".to_string(), "f".to_string(), None, None, None, None);
+        f.make_child_of(c, &mut arena).unwrap();
+        assert_eq!(format!("{:?}", arena), format!("{:?}", tree_to_arena(tree)));
     }
 }

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -64,18 +64,18 @@ pub enum ParseError {
     /// File contained lexical error and could not be lexed.
     LexicalError,
     /// File contained syntax error and could not be parsed.
-    SyntaxError,
+    SyntaxError
 }
 
 /// Given a filename (with extension), return a suitable lex file.
 pub fn get_lexer(path: &str) -> PathBuf {
     let ext = match Path::new(&path).extension() {
         Some(ext) => ext.to_str().unwrap(),
-        None => ".txt",
+        None => ".txt"
     };
     match ext {
         "java" | "calc" => canonicalize(format!("grammars/{}.l", ext)).unwrap(),
-        _ => canonicalize("grammars/txt.l".to_string()).unwrap(),
+        _ => canonicalize("grammars/txt.l".to_string()).unwrap()
     }
 }
 
@@ -83,11 +83,11 @@ pub fn get_lexer(path: &str) -> PathBuf {
 pub fn get_parser(path: &str) -> PathBuf {
     let ext = match Path::new(&path).extension() {
         Some(ext) => ext.to_str().unwrap(),
-        None => ".txt",
+        None => ".txt"
     };
     match ext {
         "java" | "calc" => canonicalize(format!("grammars/{}.y", ext)).unwrap(),
-        _ => canonicalize("grammars/txt.y".to_string()).unwrap(),
+        _ => canonicalize("grammars/txt.y".to_string()).unwrap()
     }
 }
 
@@ -179,7 +179,7 @@ fn parse_into_ast<T: PartialEq + Copy>(pt: &parser::Node<u16>,
                 };
             }
             parser::Node::Nonterm { nonterm_idx,
-                                    ref nodes, } => {
+                                    ref nodes } => {
                 // A non-terminal has no label of its own, but has a node type.
                 child_node = arena.new_node(grm.nonterm_name(nonterm_idx).to_string(),
                                             "".to_string(),

--- a/src/lib/patch.rs
+++ b/src/lib/patch.rs
@@ -53,7 +53,7 @@ const DIST_THRESHOLD: u64 = 3 * 80;
 pub struct Patch {
     action: ActionType,
     start: usize,
-    length: usize,
+    length: usize
 }
 
 impl Patch {
@@ -61,7 +61,7 @@ impl Patch {
     pub fn new(action: ActionType, start: usize, length: usize) -> Patch {
         Patch { action,
                 start,
-                length, }
+                length }
     }
 
     /// Character number where this patch begins in the original file.
@@ -95,7 +95,7 @@ impl Patch {
 pub struct Hunk {
     patches: Vec<Patch>,
     start: usize,
-    length: usize,
+    length: usize
 }
 
 impl Hunk {
@@ -103,7 +103,7 @@ impl Hunk {
     pub fn new(patch: &Patch) -> Hunk {
         Hunk { patches: vec![patch.clone()],
                start: patch.start,
-               length: patch.length, }
+               length: patch.length }
     }
 
     fn end(&self) -> usize {

--- a/src/lib/qgram.rs
+++ b/src/lib/qgram.rs
@@ -53,14 +53,14 @@ const DEFAULT_PADDING: char = REPLACEMENT_CHARACTER;
 struct QGram {
     q: u32,
     filter: bool,
-    padding: String,
+    padding: String
 }
 
 impl QGram {
     fn new(q: u32, padding: String) -> QGram {
         QGram { q,
                 filter: false,
-                padding, }
+                padding }
     }
 
     fn compare<T: Clone + Eq + Hash>(&self, a: &HashMultiSet<T>, b: &HashMultiSet<T>) -> f64 {

--- a/src/lib/similarity.rs
+++ b/src/lib/similarity.rs
@@ -111,42 +111,7 @@ impl<T: Clone + Debug + Eq + ToString + 'static> MappingStore<T> {
 mod tests {
     use ast::Arena;
     use super::*;
-
-    fn create_mult_arena() -> Arena<&'static str, FromNodeId> {
-        let mut arena = Arena::new();
-        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
-        let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
-        n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("Expr", String::from("*"), None, None, None, None);
-        n2.make_child_of(root, &mut arena).unwrap();
-        let n3 = arena.new_node("INT", String::from("3"), None, None, None, None);
-        n3.make_child_of(n2, &mut arena).unwrap();
-        let n4 = arena.new_node("INT", String::from("4"), None, None, None, None);
-        n4.make_child_of(n2, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
-";
-        assert_eq!(format1, format!("{:?}", arena));
-        arena
-    }
-
-    fn create_plus_arena() -> Arena<&'static str, FromNodeId> {
-        let mut arena = Arena::new();
-        let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
-        let n1 = arena.new_node("INT", String::from("3"), None, None, None, None);
-        n1.make_child_of(root, &mut arena).unwrap();
-        let n2 = arena.new_node("INT", String::from("4"), None, None, None, None);
-        n2.make_child_of(root, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 3
-  \"INT\" 4
-";
-        assert_eq!(format1, format!("{:?}", arena));
-        arena
-    }
+    use test_common::{create_mult_arena, create_plus_arena};
 
     #[test]
     fn num_common_descendants() {

--- a/src/lib/similarity.rs
+++ b/src/lib/similarity.rs
@@ -117,7 +117,7 @@ mod tests {
     fn num_common_descendants() {
         let mult = create_mult_arena();
         let plus = create_plus_arena();
-        let store = MappingStore::new(plus, Arena::<&'static str, ToNodeId>::from(mult));
+        let store = MappingStore::new(plus, Arena::<String, ToNodeId>::from(mult));
         store.push(NodeId::new(0), NodeId::new(2), &Default::default());
         store.push(NodeId::new(1), NodeId::new(3), &Default::default());
         store.push(NodeId::new(2), NodeId::new(4), &Default::default());

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,26 +107,26 @@ enum DebugLevel {
     Error,
     Info,
     Trace,
-    Warn,
+    Warn
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, RustcDecodable)]
 enum EditScriptGenerator {
     Chawathe96, // Default.
-    Chawathe98,
+    Chawathe98
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, RustcDecodable)]
 enum Matchers {
     GumTree, // Default.
-    Myers,
+    Myers
 }
 
 #[derive(Debug, Eq, PartialEq, RustcDecodable)]
 enum Output {
     Terminal, // Default.
     JSON,
-    None,
+    None
 }
 
 #[derive(RustcDecodable, Debug)]
@@ -147,7 +147,7 @@ struct Args {
     flag_min_height: Option<u16>,
     flag_output: Option<Output>,
     flag_store: Option<String>,
-    flag_version: bool,
+    flag_version: bool
 }
 
 fn exit_with_message(message: &str) -> ! {
@@ -162,7 +162,7 @@ fn consume_emitter_err(res: emitters::EmitterResult, filepath: &str) {
             CouldNotCreateFile => "create",
             CouldNotWriteToFile => "write to",
             CouldNotOpenFile => "open",
-            CouldNotReadFile => "read from",
+            CouldNotReadFile => "read from"
         };
         exit_with_message(&format!("Could not {} file {}.", action, filepath));
     }
@@ -180,7 +180,7 @@ fn consume_edit_script_err(error: &ast::ArenaError) -> ! {
             &s
         }
         NodeHasTooManyChildren => "Could not create edit script, NodeId had more than one child.",
-        NodeIdsAreIdentical => "Could not create edit script, NodeIds were identical.",
+        NodeIdsAreIdentical => "Could not create edit script, NodeIds were identical."
     };
     exit_with_message(message);
 }
@@ -253,7 +253,7 @@ fn parse_file<T: Copy + PartialEq>(filename: &str,
             BrokenParser => format!("Could not build parser {:?}.", yacc_path),
             LexicalError => format!("Lexical error in {}.", filename),
             SyntaxError => format!("Syntax error in {}.", filename),
-            _ => format!("Error parsing {}.", filename),
+            _ => format!("Error parsing {}.", filename)
         }
     };
     parser::parse_file::<T>(filename, lexer_path, yacc_path).map_err(error_to_str)
@@ -288,14 +288,12 @@ fn get_parsers(args: &Args) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
     // TODO: create a HashMap of file extensions -> lex/yacc files.
     match env::current_exe() {
         Ok(p) => p,
-        Err(_) => exit_with_message("Cannot determine which directory the executable is in."),
+        Err(_) => exit_with_message("Cannot determine which directory the executable is in.")
     };
 
     match Path::new(&args.arg_base_file).extension() {
         Some(_) => (),
-        None => {
-            exit_with_message(&format!("Cannot determine file type of {}.", args.arg_base_file))
-        }
+        None => exit_with_message(&format!("Cannot determine file type of {}.", args.arg_base_file))
     };
     // Lexer path for first input file.
     let lexer1 = if !args.flag_grammar.is_empty() {
@@ -320,9 +318,7 @@ fn get_parsers(args: &Args) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
 
     match Path::new(&args.arg_diff_file).extension() {
         Some(_) => (),
-        None => {
-            exit_with_message(&format!("Cannot determine file type of {}.", args.arg_diff_file))
-        }
+        None => exit_with_message(&format!("Cannot determine file type of {}.", args.arg_diff_file))
     };
     // Lexer path for second input file.
     let lexer2 = if !args.flag_grammar.is_empty() && args.flag_grammar.len() > 1 {
@@ -478,7 +474,7 @@ fn main() {
 
     let edit_script = match generator_config.generate_script(&store) {
         Ok(script) => script,
-        Err(err) => consume_edit_script_err(&err),
+        Err(err) => consume_edit_script_err(&err)
     };
 
     if args.flag_store.is_some() {

--- a/tests/test_edit_script.rs
+++ b/tests/test_edit_script.rs
@@ -51,16 +51,14 @@ use common::check_files;
 
 #[test]
 fn test_both_arenas_empty() {
-    let ast_from = Arena::new();
+    let ast_from: Arena<String, _> = Arena::new();
     let ast_to = Arena::new();
-    // Generate mappings between ASTs.
     let matcher_config = MyersConfig::new();
     let store = matcher_config.match_trees(ast_from, ast_to);
     assert!(store.from.borrow().is_empty());
     assert!(store.to.borrow().is_empty());
-    // Generate an edit script.
-    let gen_config: Box<EditScriptGenerator<String>> = Box::new(Chawathe96Config::new());
-    let _edit_script_wrapped = gen_config.generate_script(&store);
+    Box::new(Chawathe96Config::new()).generate_script(&store)
+                                     .ok();
 }
 
 #[test]
@@ -68,14 +66,12 @@ fn test_both_arenas_empty() {
 fn test_from_arena_empty() {
     let ast_from = Arena::new();
     let ast_to = parse_file("tests/empty.calc", &get_lexer("grammars/calc.l"), &get_parser("grammars/calc.y")).unwrap();
-    // Generate mappings between ASTs.
     let matcher_config = MyersConfig::new();
     let store = matcher_config.match_trees(ast_from, ast_to);
     assert!(store.from.borrow().is_empty());
     assert!(store.to.borrow().is_empty());
-    // Generate an edit script.
-    let gen_config: Box<EditScriptGenerator<String>> = Box::new(Chawathe96Config::new());
-    let _edit_script_wrapped = gen_config.generate_script(&store); // Panic.
+    Box::new(Chawathe96Config::new()).generate_script(&store)
+                                     .ok();
 }
 
 #[test]
@@ -83,14 +79,12 @@ fn test_from_arena_empty() {
 fn test_to_arena_empty() {
     let ast_from = parse_file("tests/empty.calc", &get_lexer("grammars/calc.l"), &get_parser("grammars/calc.y")).unwrap();
     let ast_to = Arena::new();
-    // Generate mappings between ASTs.
     let matcher_config = MyersConfig::new();
     let store = matcher_config.match_trees(ast_from, ast_to);
     assert!(store.from.borrow().is_empty());
     assert!(store.to.borrow().is_empty());
-    // Generate an edit script.
-    let gen_config: Box<EditScriptGenerator<String>> = Box::new(Chawathe96Config::new());
-    gen_config.generate_script(&store).ok(); // Panic.
+    Box::new(Chawathe96Config::new()).generate_script(&store)
+                                     .ok();
 }
 
 #[test]


### PR DESCRIPTION
This PR:

 * Factors out common ASTs used in many unit tests across the code base.
 * Provides an API for loading ASTs from XML in test config. 
 * Converts the common parse trees to XML.

The reason for doing this, other than avoiding code duplication, is to cut down on the amount of code in the unit tests, which is currently large and broadly unreadable. Also, this will make it easier in other PRs to load XML test data similar to that in the GT code base.