### PR TITLE
Prefix lines of pretty-printed ASTs with NodeIds.

### DIFF
--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -648,11 +648,11 @@ mod test {
     #[test]
     fn apply_delete_leaf() {
         let mut arena = create_mult_arena();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
 
         assert_eq!(format1, format!("{:?}", arena));
@@ -660,9 +660,9 @@ mod test {
         del1.apply(&mut arena).unwrap();
         let mut del2 = Delete::new(NodeId::new(4));
         del2.apply(&mut arena).unwrap();
-        let format2 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
+        let format2 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }
@@ -671,11 +671,11 @@ mod test {
     #[should_panic]
     fn apply_delete_branch() {
         let mut arena = create_mult_arena();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let mut del = Delete::new(NodeId::new(2));
@@ -686,21 +686,21 @@ mod test {
     fn apply_insert() {
         let mut arena = create_mult_arena();
         let n5 = arena.new_node("INT".to_string(), "100".to_string(), None, None, None, None);
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let mut ins = Insert::new(n5, Some(NodeId::new(2)), 0);
         ins.apply(&mut arena).unwrap();
-        let format2 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 100
-    \"INT\" 3
-    \"INT\" 4
+        let format2 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+005:     \"INT\" 100
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }
@@ -709,21 +709,21 @@ mod test {
     fn apply_insert_new_root() {
         let mut arena = create_mult_arena();
         let n5 = arena.new_node("Expr".to_string(), "-".to_string(), None, None, None, None);
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let mut ins = Insert::new(n5, None, 0);
         ins.apply(&mut arena).unwrap();
-        let format2 = "\"Expr\" -
-  \"Expr\" +
-    \"INT\" 1
-    \"Expr\" *
-      \"INT\" 3
-      \"INT\" 4
+        let format2 = "005: \"Expr\" -
+000:   \"Expr\" +
+001:     \"INT\" 1
+002:     \"Expr\" *
+003:       \"INT\" 3
+004:       \"INT\" 4
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }
@@ -731,20 +731,20 @@ mod test {
     #[test]
     fn apply_move() {
         let mut arena = create_mult_arena();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let mut mov = Move::new(NodeId::new(4), NodeId::new(2), 0);
         mov.apply(&mut arena).unwrap();
-        let format2 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 4
-    \"INT\" 3
+        let format2 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+004:     \"INT\" 4
+003:     \"INT\" 3
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }
@@ -753,20 +753,20 @@ mod test {
     fn apply_update() {
         let mut arena = create_mult_arena();
         assert_eq!(5, arena.size());
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let mut upd = Update::new(NodeId::new(2), "Expr".to_string(), "+".to_string());
         upd.apply(&mut arena).unwrap();
-        let format2 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" +
-    \"INT\" 3
-    \"INT\" 4
+        let format2 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" +
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }
@@ -774,11 +774,11 @@ mod test {
     #[test]
     fn apply_to_list1() {
         let mut arena = create_mult_arena();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         let n5 = arena.new_node("INT".to_string(), "100".to_string(), None, None, None, None);
         let n6 = arena.new_node("INT".to_string(), "99".to_string(), None, None, None, None);
@@ -803,11 +803,11 @@ mod test {
         assert_eq!(6, actions.size());
         // Apply action list.
         actions.apply(&mut arena).unwrap();
-        let format2 = "\"Expr\" *
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 99
-    \"INT\" 100
+        let format2 = "000: \"Expr\" *
+001:   \"INT\" 1
+002:   \"Expr\" *
+006:     \"INT\" 99
+005:     \"INT\" 100
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }
@@ -815,11 +815,11 @@ mod test {
     #[test]
     fn apply_to_list2() {
         let mut arena = create_mult_arena();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let n5 = arena.new_node("INT".to_string(), "2".to_string(), None, None, None, None);
@@ -841,11 +841,11 @@ mod test {
         assert_eq!(3, actions.size());
         // Apply action list.
         actions.apply(&mut arena).unwrap();
-        let format2 = "\"Expr\" *
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 2
-    \"INT\" 3
+        let format2 = "000: \"Expr\" *
+001:   \"INT\" 1
+002:   \"Expr\" *
+005:     \"INT\" 2
+003:     \"INT\" 3
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -293,8 +293,11 @@ impl<T: Clone + PartialEq, U: PartialEq + Copy> Arena<T, U> {
     }
 }
 
-// Should have similar output as lrpar::parser::Node<TokId>::pretty_print().
 impl<T: fmt::Debug + Clone, U: PartialEq + Copy> fmt::Debug for Arena<T, U> {
+    /// Should have similar output to `lrpar::parser::Node<TokId>::pretty_print`.
+    ///
+    /// Each line is prefixed with the id of the node represent on it,
+    /// e.g. `005: "INT" 1`
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.nodes.is_empty() {
             // Case where self.root is None.
@@ -306,6 +309,7 @@ impl<T: fmt::Debug + Clone, U: PartialEq + Copy> fmt::Debug for Arena<T, U> {
         while !stack.is_empty() {
             let (indent, id) = stack.pop().unwrap();
             let node = &self.nodes[id.index];
+            formatted.push_str(&format!("{:03}: ", id.index));
             for _ in 0..indent {
                 formatted.push_str("  ");
             }
@@ -951,11 +955,11 @@ mod tests {
         let from_arena = create_mult_arena();
         let coerced_to_arena = Arena::<String, ToNodeId>::from(from_arena.clone());
         let coerced_from_arena = Arena::<String, FromNodeId>::from(coerced_to_arena.clone());
-        let format = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format, format!("{:?}", from_arena));
         assert_eq!(format, format!("{:?}", coerced_to_arena));
@@ -1024,15 +1028,15 @@ mod tests {
         let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
         let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let new_root = arena.new_node("INT", String::from("2"), None, None, None, None);
         assert!(arena.new_root(new_root).is_ok());
-        let format2 = "\"INT\" 2
-  \"Expr\" +
-    \"INT\" 1
+        let format2 = "002: \"INT\" 2
+000:   \"Expr\" +
+001:     \"INT\" 1
 ";
         assert_eq!(format2, format!("{:?}", arena));
         assert_eq!(arena.root().unwrap(), new_root);
@@ -1049,15 +1053,15 @@ mod tests {
         let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
         let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let new_root = arena.new_node("INT", String::from("2"), None, None, None, None);
         assert!(arena.new_root(new_root).is_ok());
-        let format2 = "\"INT\" 2
-  \"Expr\" +
-    \"INT\" 1
+        let format2 = "002: \"INT\" 2
+000:   \"Expr\" +
+001:     \"INT\" 1
 ";
         assert_eq!(format2, format!("{:?}", arena));
         assert!(arena.delete_root().is_ok());
@@ -1076,8 +1080,8 @@ mod tests {
         let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
         let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let new_root = arena.new_node("INT", String::from("2"), None, None, None, None);
@@ -1095,8 +1099,8 @@ mod tests {
         let root = arena.new_node("Expr", String::from("+"), None, None, None, None);
         let n1 = arena.new_node("INT", String::from("1"), None, None, None, None);
         n1.make_child_of(root, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let new_root = arena.new_node("INT", String::from("2"), None, None, None, None);
@@ -1180,18 +1184,18 @@ mod tests {
         n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node("INT", String::from("2"), None, None, None, None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"INT\" 2
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"INT\" 2
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let n3 = arena.new_node("INT", String::from("100"), None, None, None, None);
         // Make first child.
         n3.make_nth_child_of(n2, 0, &mut arena).unwrap();
-        let format2 = "\"Expr\" +
-  \"INT\" 1
-  \"INT\" 2
-    \"INT\" 100
+        let format2 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"INT\" 2
+003:     \"INT\" 100
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }
@@ -1206,18 +1210,18 @@ mod tests {
         n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node("INT", String::from("2"), None, None, None, None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"INT\" 2
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"INT\" 2
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let n3 = arena.new_node("INT", String::from("100"), None, None, None, None);
         // Make last child.
         n3.make_nth_child_of(root, 2, &mut arena).unwrap();
-        let format2 = "\"Expr\" +
-  \"INT\" 1
-  \"INT\" 2
-  \"INT\" 100
+        let format2 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"INT\" 2
+003:   \"INT\" 100
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }
@@ -1232,18 +1236,18 @@ mod tests {
         n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node("INT", String::from("2"), None, None, None, None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"INT\" 2
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"INT\" 2
 ";
         assert_eq!(format1, format!("{:?}", arena));
         let n3 = arena.new_node("INT", String::from("100"), None, None, None, None);
         // Make second child.
         n3.make_nth_child_of(root, 1, &mut arena).unwrap();
-        let format2 = "\"Expr\" +
-  \"INT\" 1
-  \"INT\" 100
-  \"INT\" 2
+        let format2 = "000: \"Expr\" +
+001:   \"INT\" 1
+003:   \"INT\" 100
+002:   \"INT\" 2
 ";
         assert_eq!(format2, format!("{:?}", arena));
     }
@@ -1288,9 +1292,9 @@ mod tests {
         n1.make_child_of(root, &mut arena).unwrap();
         let n2 = arena.new_node("INT", String::from("2"), None, None, None, None);
         n2.make_child_of(root, &mut arena).unwrap();
-        let expected = "\"Expr\" +
-  \"INT\" 1
-  \"INT\" 2
+        let expected = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"INT\" 2
 ";
         assert_eq!(expected, format!("{:?}", arena));
     }
@@ -1355,15 +1359,15 @@ mod tests {
     fn detach_1() {
         let mut arena = create_mult_arena();
         let root = NodeId::new(0);
-        let first_format = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let first_format = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(first_format, format!("{:?}", arena));
         root.detach_with_children(&mut arena).unwrap();
-        let second_format = "\"Expr\" +\n";
+        let second_format = "000: \"Expr\" +\n";
         assert_eq!(second_format, format!("{:?}", arena));
     }
 
@@ -1371,16 +1375,16 @@ mod tests {
     fn detach_2() {
         let mut arena = create_mult_arena();
         let n2 = NodeId::new(2);
-        let first_format = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let first_format = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(first_format, format!("{:?}", arena));
         n2.detach_with_children(&mut arena).unwrap();
-        let second_format = "\"Expr\" +
-  \"INT\" 1
+        let second_format = "000: \"Expr\" +
+001:   \"INT\" 1
 ";
         assert_eq!(second_format, format!("{:?}", arena));
     }
@@ -1637,11 +1641,11 @@ mod tests {
     #[test]
     fn height() {
         let arena = create_mult_arena();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
         assert_eq!(3, NodeId::new(0).height(&arena));
@@ -1654,11 +1658,11 @@ mod tests {
     #[test]
     fn size_on_nodeid() {
         let arena = create_mult_arena();
-        let format1 = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let format1 = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(format1, format!("{:?}", arena));
         assert_eq!(5, NodeId::new(0).size(&arena));

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -197,11 +197,11 @@ pub mod test_common {
     </Tree>
     ";
         let arena = load_xml_ast(xml);
-        let expected_format = "\"Expr\" +
-  \"INT\" 1
-  \"Expr\" *
-    \"INT\" 3
-    \"INT\" 4
+        let expected_format = "000: \"Expr\" +
+001:   \"INT\" 1
+002:   \"Expr\" *
+003:     \"INT\" 3
+004:     \"INT\" 4
 ";
         assert_eq!(expected_format, format!("{:?}", arena));
         arena
@@ -220,9 +220,9 @@ pub mod test_common {
     </Tree>
     ";
         let arena = load_xml_ast(xml);
-        let expected_format = "\"Expr\" +
-  \"INT\" 3
-  \"INT\" 4
+        let expected_format = "000: \"Expr\" +
+001:   \"INT\" 3
+002:   \"INT\" 4
 ";
         assert_eq!(expected_format, format!("{:?}", arena));
         arena

--- a/tests/test_ast.rs
+++ b/tests/test_ast.rs
@@ -59,13 +59,13 @@ fn compare_ast_dump_to_lrpar_output(filepath: &str, expected: &str) {
 fn test_empty_calc() {
     compare_ast_dump_to_lrpar_output(
         "tests/empty.calc",
-        "\"^~\"
-  \"~\"
-    \"WHITESPACE\"  \n
-    \"~\"
-  \"Expr\"
-    \"Term\"
-      \"Factor\"
+        "000: \"^~\"
+001:   \"~\"
+002:     \"WHITESPACE\"  \n
+003:     \"~\"
+004:   \"Expr\"
+005:     \"Term\"
+006:       \"Factor\"
 ",
     );
 }
@@ -74,15 +74,15 @@ fn test_empty_calc() {
 fn test_one_calc() {
     compare_ast_dump_to_lrpar_output(
         "tests/one.calc",
-        "\"^~\"
-  \"~\"
-  \"Expr\"
-    \"Term\"
-      \"Factor\"
-        \"INT\" 1
-        \"~\"
-          \"WHITESPACE\" \n
-          \"~\"
+        "000: \"^~\"
+001:   \"~\"
+002:   \"Expr\"
+003:     \"Term\"
+004:       \"Factor\"
+005:         \"INT\" 1
+006:         \"~\"
+007:           \"WHITESPACE\" \n
+008:           \"~\"
 ",
     );
 }
@@ -91,22 +91,22 @@ fn test_one_calc() {
 fn test_add_calc() {
     compare_ast_dump_to_lrpar_output(
         "tests/add.calc",
-        "\"^~\"
-  \"~\"
-  \"Expr\"
-    \"Term\"
-      \"Factor\"
-        \"INT\" 1
-        \"~\"
-    \"PLUS\" +
-    \"~\"
-    \"Expr\"
-      \"Term\"
-        \"Factor\"
-          \"INT\" 2
-          \"~\"
-            \"WHITESPACE\" \n
-            \"~\"
+        "000: \"^~\"
+001:   \"~\"
+002:   \"Expr\"
+003:     \"Term\"
+004:       \"Factor\"
+005:         \"INT\" 1
+006:         \"~\"
+007:     \"PLUS\" +
+008:     \"~\"
+009:     \"Expr\"
+010:       \"Term\"
+011:         \"Factor\"
+012:           \"INT\" 2
+013:           \"~\"
+014:             \"WHITESPACE\" \n
+015:             \"~\"
 ",
     );
 }
@@ -115,28 +115,28 @@ fn test_add_calc() {
 fn test_mult_calc() {
     compare_ast_dump_to_lrpar_output(
         "tests/mult.calc",
-        "\"^~\"
-  \"~\"
-  \"Expr\"
-    \"Term\"
-      \"Factor\"
-        \"INT\" 3
-        \"~\"
-      \"MULT\" *
-      \"~\"
-      \"Term\"
-        \"Factor\"
-          \"INT\" 1
-          \"~\"
-    \"PLUS\" +
-    \"~\"
-    \"Expr\"
-      \"Term\"
-        \"Factor\"
-          \"INT\" 2
-          \"~\"
-            \"WHITESPACE\" \n
-            \"~\"
+        "000: \"^~\"
+001:   \"~\"
+002:   \"Expr\"
+003:     \"Term\"
+004:       \"Factor\"
+005:         \"INT\" 3
+006:         \"~\"
+007:       \"MULT\" *
+008:       \"~\"
+009:       \"Term\"
+010:         \"Factor\"
+011:           \"INT\" 1
+012:           \"~\"
+013:     \"PLUS\" +
+014:     \"~\"
+015:     \"Expr\"
+016:       \"Term\"
+017:         \"Factor\"
+018:           \"INT\" 2
+019:           \"~\"
+020:             \"WHITESPACE\" \n
+021:             \"~\"
 ",
     );
 }
@@ -145,43 +145,41 @@ fn test_mult_calc() {
 fn test_nested_comment_java() {
     compare_ast_dump_to_lrpar_output(
         "tests/NestedComment.java",
-        "\"^~\"
-  \"~\"
-    \"COMMENT\" /*
- * // Single line comment nested in multi-line comment.
- */
-    \"~\"
-      \"WHITESPACE\" \n\n      \"~\"
-  \"goal\"
-    \"compilation_unit\"
-      \"type_declarations_opt\"
-        \"type_declarations\"
-          \"type_declaration\"
-            \"class_declaration\"
-              \"modifiers_opt\"
-                \"modifiers\"
-                  \"modifier\"
-                    \"PUBLIC\" public
-                    \"~\"
-                      \"WHITESPACE\"  \n                      \"~\"
-              \"CLASS\" class
-              \"~\"
-                \"WHITESPACE\"  \n                \"~\"
-              \"IDENTIFIER\" NestedComment
-              \"~\"
-                \"WHITESPACE\"  \n                \"~\"
-              \"type_parameters_opt\"
-              \"super_opt\"
-              \"interfaces_opt\"
-              \"class_body\"
-                \"LBRACE\" {
-                \"~\"
-                \"class_body_declarations_opt\"
-                \"RBRACE\" }
-                \"~\"
-                  \"WHITESPACE\" \n\n                  \"~\"
-",
-    );
+        "000: \"^~\"
+001:   \"~\"
+002:     \"COMMENT\" /*\n * // Single line comment nested in multi-line comment.\n */
+003:     \"~\"
+004:       \"WHITESPACE\" \n
+005:       \"~\"
+006:   \"goal\"
+007:     \"compilation_unit\"
+008:       \"type_declarations_opt\"
+009:         \"type_declarations\"
+010:           \"type_declaration\"
+011:             \"class_declaration\"
+012:               \"modifiers_opt\"
+013:                 \"modifiers\"
+014:                   \"modifier\"
+015:                     \"PUBLIC\" public
+016:                     \"~\"
+017:                       \"WHITESPACE\"  \n018:                       \"~\"
+019:               \"CLASS\" class
+020:               \"~\"
+021:                 \"WHITESPACE\"  \n022:                 \"~\"
+023:               \"IDENTIFIER\" NestedComment
+024:               \"~\"
+025:                 \"WHITESPACE\"  \n026:                 \"~\"
+027:               \"type_parameters_opt\"
+028:               \"super_opt\"
+029:               \"interfaces_opt\"
+030:               \"class_body\"
+031:                 \"LBRACE\" {
+032:                 \"~\"
+033:                 \"class_body_declarations_opt\"
+034:                 \"RBRACE\" }
+035:                 \"~\"
+036:                   \"WHITESPACE\" \n
+037:                   \"~\"\n");
 }
 
 #[test]


### PR DESCRIPTION
This is intended to help with debugging.
As an example, this AST:
```
^~"
  "~"
  "Expr"
    "Term"
      "Factor"
        "INT" 1
```
becomes:
```
000: "^~"
001:   "~"
002:   "Expr"
003:     "Term"
004:       "Factor"
005:         "INT" 1
```