### PR TITLE
Revert "Fix rust-nightly version in Travis."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: nightly-2018-03-25
+rust: nightly
 cache: cargo
 before_script:
 - export PATH="$PATH:$HOME/.cargo/bin"


### PR DESCRIPTION
This reverts commit d078a2818b2a77c93adc26461c62121009b8086a which fixed Travis to an old version of the nightly build.