### PR TITLE
Cleaner clippy output.

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -38,6 +38,11 @@
 #![feature(test)]
 #![feature(try_from)]
 
+#![cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default))]
+#![cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+#![cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
+
 extern crate cfgrammar;
 extern crate crypto;
 extern crate dot;


### PR DESCRIPTION
When I run clippy, I get several screens of output that I'm not interested in, which makes it more likely that I'll miss something important. This PR suppresses some warnings that we do not care about.

Specifically:

  * Missing Default() traits.
  * High cyclomatic complexity and too many function arguments.
  * High type complexity.