### PR TITLE
Port to grmtools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rust-crypto = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 term = "0.5"
-cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
-lrlex = { git = "http://github.com/softdevteam/lrlex" }
-lrpar = { git = "http://github.com/softdevteam/lrpar" }
-lrtable = { git = "http://github.com/softdevteam/lrtable" }
+cfgrammar = { git = "https://github.com/softdevteam/grmtools" }
+lrlex = { git = "http://github.com/softdevteam/grmtools" }
+lrpar = { git = "http://github.com/softdevteam/grmtools" }
+lrtable = { git = "http://github.com/softdevteam/grmtools" }

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -50,6 +50,12 @@ use lrtable::{from_yacc, Minimiser};
 
 use ast::{Arena, NodeId};
 
+/// Needed for grmtools: must be big enough to index all nonterminals and (separately) to index all
+/// productions in grammars.
+type StorageT = u16;
+/// Needed for grmtools: must be big enough to index all terminals in the grammar.
+type TokId = u16;
+
 /// Errors raised when parsing a source file.
 #[derive(Debug)]
 pub enum ParseError {
@@ -114,15 +120,15 @@ pub fn parse_string<T: PartialEq + Copy>(input: &str,
     let lexs = read_file(lex_path)?;
     let grms = read_file(yacc_path)?;
 
-    let mut lexerdef = build_lex::<u16>(&lexs).map_err(|_| ParseError::BrokenLexer)?;
-    let grm = YaccGrammar::<u16>::new_with_storaget(YaccKind::Eco, &grms)
-                                 .map_err(|_| ParseError::BrokenParser)?;
+    let mut lexerdef = build_lex::<TokId>(&lexs).map_err(|_| ParseError::BrokenLexer)?;
+    let grm = YaccGrammar::<StorageT>::new_with_storaget(YaccKind::Eco, &grms)
+                                      .map_err(|_| ParseError::BrokenParser)?;
     let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).map_err(|_| ParseError::BrokenParser)?;
 
     // Sync up the IDs of terminals in the lexer and parser.
     let rule_ids = grm.terms_map()
                       .iter()
-                      .map(|(&n, &i)| (n, u16::try_from(usize::from(i)).unwrap()))
+                      .map(|(&n, &i)| (n, TokId::try_from(usize::from(i)).unwrap()))
                       .collect();
     lexerdef.set_rule_ids(&rule_ids);
 
@@ -148,9 +154,9 @@ pub fn parse_file<T: PartialEq + Copy>(input_path: &str,
 }
 
 // Turn a grammar, parser and input string into an AST arena.
-fn parse_into_ast<T: PartialEq + Copy>(pt: &parser::Node<u16, u16>,
-                                       lexer: &Lexer<u16>,
-                                       grm: &YaccGrammar<u16>,
+fn parse_into_ast<T: PartialEq + Copy>(pt: &parser::Node<StorageT, TokId>,
+                                       lexer: &Lexer<TokId>,
+                                       grm: &YaccGrammar<StorageT>,
                                        input: &str)
                                        -> Arena<String, T> {
     let mut arena = Arena::new();


### PR DESCRIPTION
This PR first ports Diffract to use the grmtools repositories and then factors out the token ID type (and another type that grmtools now requires) into `type` declarations, so that one only needs to chang things in one place.