### PR TITLE
Implement the Error trait.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dot = "0.1"
 env_logger = "0.5"
 log = "0.4"
 multiset = { git = "https://github.com/jmitchell/multiset" }
+quick-error = "1.2"
 rust-crypto = "0.2"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/lib/action.rs
+++ b/src/lib/action.rs
@@ -512,7 +512,8 @@ impl<T: Clone + fmt::Debug + Eq + PartialEq + ToString> ApplyAction<T> for Inser
 
 impl<T: Clone + fmt::Debug + Eq + PartialEq + ToString + 'static> ApplyAction<T> for Move {
     fn apply(&mut self, arena: &mut Arena<T, SrcNodeId>) -> ArenaResult {
-        self.src_node.make_nth_child_of(self.parent, self.pos, arena)
+        self.src_node
+            .make_nth_child_of(self.parent, self.pos, arena)
     }
     impl_compare!();
 }
@@ -520,7 +521,7 @@ impl<T: Clone + fmt::Debug + Eq + PartialEq + ToString + 'static> ApplyAction<T>
 impl<T: Clone + fmt::Debug + Eq + PartialEq + ToString + 'static> ApplyAction<T> for Update<T> {
     fn apply(&mut self, arena: &mut Arena<T, SrcNodeId>) -> ArenaResult {
         if !arena.contains(self.node) {
-            return Err(ArenaError::NodeIdNotFound);
+            return Err(ArenaError::NodeIdNotFound(self.node.id()));
         }
         arena[self.node].ty = self.ty.clone();
         arena[self.node].label = self.label.clone();
@@ -532,7 +533,7 @@ impl<T: Clone + fmt::Debug + Eq + PartialEq + ToString + 'static> ApplyAction<T>
 impl<T: Clone + fmt::Debug + Eq + PartialEq + ToString + 'static> ApplyAction<T> for Copy {
     fn apply(&mut self, arena: &mut Arena<T, SrcNodeId>) -> ArenaResult {
         if !arena.contains(self.src_node) {
-            return Err(ArenaError::NodeIdNotFound);
+            return Err(ArenaError::NodeIdNotFound(self.src_node.id()));
         }
         self.src_node.copy_subtree(self.parent, self.pos, arena)
     }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -52,6 +52,8 @@ extern crate lrlex;
 extern crate lrpar;
 extern crate lrtable;
 extern crate multiset;
+#[macro_use]
+extern crate quick_error;
 extern crate term;
 extern crate test;
 

--- a/tests/test_ast.rs
+++ b/tests/test_ast.rs
@@ -227,7 +227,7 @@ fn test_lexical_err() {
     let filepath = "tests/calc_lexical_err.calc";
     let ast_result = parse_file::<SrcNodeId>(filepath, &get_lexer(filepath), &get_parser(filepath));
     match ast_result {
-        Err(ParseError::LexicalError) => assert!(true),
+        Err(ParseError::LexicalError(_)) => assert!(true),
         Err(e) => panic!("Expected LexicalError error, got: {:?}", e),
         Ok(_) => panic!("Expected FileNotFound error, got an AST")
     }
@@ -238,7 +238,7 @@ fn test_syntax_err() {
     let filepath = "tests/calc_syntax_err.calc";
     let ast_result = parse_file::<SrcNodeId>(filepath, &get_lexer(filepath), &get_parser(filepath));
     match ast_result {
-        Err(ParseError::SyntaxError) => assert!(true),
+        Err(ParseError::SyntaxError(_)) => assert!(true),
         Err(e) => panic!("Expected SyntaxError error, got: {:?}", e),
         Ok(_) => panic!("Expected FileNotFound error, got an AST")
     }


### PR DESCRIPTION
This commit implements the standard library `Error` trait for all public errors in the crate (`ArenaError`, `EmitterError`, `ParseError`). The `quick_error` macro (from the quick-error crate) is used to simplify error definitions. This makes error handling more idiomatic.

In addition, we now need much less custom error handling in `main.rs`, as each error "holds" its own description and error message. This also makes the code a little easier to read, as error definitions and descriptions appear together in the relevant files.

To make this happen, some errors now hold extra information (such as file names and AST node ids. Errors in `ArenaError` which relate to nodes having unexpectedly few or many children now hold the id of the erroneous node, rather than the number of children that node is related to.

Fixes #115 